### PR TITLE
Add multi-column product grid options

### DIFF
--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -122,25 +122,16 @@
   
   /* New layout options CSS */
   @media (max-width: 749px) {
-    .product-grid.two-col {
-      grid-template-columns: repeat(2, 1fr) !important;
-    }
-    .product-grid.mixed-layout {
-      grid-template-columns: repeat(2, 1fr) !important;
-    }
-    .product-grid.mixed-layout li:nth-child(3n+1) {
-      grid-column: span 2;
-    }
+    .product-grid.one-col { grid-template-columns: repeat(1, 1fr) !important; }
+    .product-grid.two-col { grid-template-columns: repeat(2, 1fr) !important; }
+    .product-grid.three-col { grid-template-columns: repeat(3, 1fr) !important; }
   }
   @media (min-width: 750px) {
-    .product-grid.mixed-layout {
-      grid-template-columns: repeat(12, 1fr) !important;
-    }
-    .product-grid.mixed-layout li:nth-child(3n+1) {
-      grid-column: span 1;
-    }
-    .product-grid.mixed-layout .card__content,
-    .product-grid.mixed-layout .product-card-plus {
+    .product-grid.one-col { grid-template-columns: repeat(1, 1fr) !important; }
+    .product-grid.two-col { grid-template-columns: repeat(2, 1fr) !important; }
+    .product-grid.three-col { grid-template-columns: repeat(3, 1fr) !important; }
+    .product-grid.three-col .card__content,
+    .product-grid.three-col .product-card-plus {
       display: none !important;
     }
   }
@@ -266,24 +257,9 @@
   <!-- Grid Controls: Layout options and Facets toggle button in the same row -->
   <div class="grid-controls page-width">
     <div class="layout-options">
-      <!-- Two-Column Button -->
-      <button type="button" id="layout-two-col" class="layout-option-button active">
-        <span class="grid-icon grid-icon--full">
-          {{ 'grid_1_full_3.svg' | inline_asset_content }}
-        </span>
-        <span class="grid-icon grid-icon--empty">
-          {{ 'grid_1_empty_3.svg' | inline_asset_content }}
-        </span>
-      </button>
-      <!-- Mixed Layout Button -->
-      <button type="button" id="layout-mixed" class="layout-option-button">
-        <span class="grid-icon grid-icon--full">
-          {{ 'grid_2_full_2.svg' | inline_asset_content }}
-        </span>
-        <span class="grid-icon grid-icon--empty">
-          {{ 'grid_2_empty_3.svg' | inline_asset_content }}
-        </span>
-      </button>
+      <button type="button" id="layout-one-col" class="layout-option-button">1</button>
+      <button type="button" id="layout-two-col" class="layout-option-button active">2</button>
+      <button type="button" id="layout-three-col" class="layout-option-button">3</button>
     </div>
     <div class="facets-toggle-container">
       <button type="button" id="facets-toggle-button" class="facets-toggle-button">
@@ -409,33 +385,39 @@
   // Global initializer for grid options
   window.initializeGridOptions = function() {
     var grid = document.getElementById('product-grid');
+    var btnOneCol = document.getElementById('layout-one-col');
     var btnTwoCol = document.getElementById('layout-two-col');
-    var btnMixed = document.getElementById('layout-mixed');
-    
-    if (!grid || !btnTwoCol || !btnMixed) return;
-    
-    // Optionally, remove any previously bound events
+    var btnThreeCol = document.getElementById('layout-three-col');
+
+    if (!grid || !btnOneCol || !btnTwoCol || !btnThreeCol) return;
+
+    btnOneCol.replaceWith(btnOneCol.cloneNode(true));
     btnTwoCol.replaceWith(btnTwoCol.cloneNode(true));
-    btnMixed.replaceWith(btnMixed.cloneNode(true));
-    
-    // Re-select after cloning
+    btnThreeCol.replaceWith(btnThreeCol.cloneNode(true));
+
+    btnOneCol = document.getElementById('layout-one-col');
     btnTwoCol = document.getElementById('layout-two-col');
-    btnMixed = document.getElementById('layout-mixed');
-    
-    btnTwoCol.addEventListener('click', function() {
-      grid.classList.remove('mixed-layout');
-      if (window.innerWidth < 750) {
-        grid.classList.add('two-col');
-      } else {
-        grid.classList.remove('two-col');
-      }
-      btnTwoCol.classList.add('active');
-      btnMixed.classList.remove('active');
+    btnThreeCol = document.getElementById('layout-three-col');
+
+    btnOneCol.addEventListener('click', function() {
+      grid.classList.remove('two-col', 'three-col');
+      grid.classList.add('one-col');
+      btnOneCol.classList.add('active');
+      btnTwoCol.classList.remove('active');
+      btnThreeCol.classList.remove('active');
     });
-    btnMixed.addEventListener('click', function() {
-      grid.classList.remove('two-col');
-      grid.classList.add('mixed-layout');
-      btnMixed.classList.add('active');
+    btnTwoCol.addEventListener('click', function() {
+      grid.classList.remove('one-col', 'three-col');
+      grid.classList.add('two-col');
+      btnTwoCol.classList.add('active');
+      btnOneCol.classList.remove('active');
+      btnThreeCol.classList.remove('active');
+    });
+    btnThreeCol.addEventListener('click', function() {
+      grid.classList.remove('one-col', 'two-col');
+      grid.classList.add('three-col');
+      btnThreeCol.classList.add('active');
+      btnOneCol.classList.remove('active');
       btnTwoCol.classList.remove('active');
     });
   };


### PR DESCRIPTION
## Summary
- add 1, 2 and 3 column layout options to the collection grid
- hide product details in the 3-column layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c862036b083259cbef3c4bed1fa00