### PR TITLE
Ensure predictive search results overlay sticky product bar

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2064,7 +2064,7 @@ input[type='checkbox'] {
   right: 0;
   bottom: 0;
   background: rgb(var(--color-background));
-  z-index: 4;
+  z-index: 80; /* Elevate modal above sticky product bar */
   display: flex;
   justify-content: center;
   align-items: center;

--- a/assets/component-predictive-search.css
+++ b/assets/component-predictive-search.css
@@ -16,6 +16,10 @@
   -webkit-overflow-scrolling: touch;
 }
 
+#predictive-search-results {
+  position: relative; /* Allow z-index adjustments */
+}
+
 .predictive-search--search-template {
   z-index: 2;
   width: calc(100% + 0.2rem);


### PR DESCRIPTION
## Summary
- increase predictive search z-index so suggestions are not hidden by sticky product bar on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906fe60f0c83258041bb49caf769fd