### PR TITLE
Move quick add button next to swatches

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -4075,17 +4075,13 @@ font-style: normal;
 
 
 .product-card-plus {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
+  position: relative;
+  margin-left: auto;
   z-index: 20;
 }
 
 .product-card-plus .plus-icon {
-  position: absolute;
-  bottom: 0rem;
-  right: 0rem;
+  position: static;
   display: flex;
   width: 3rem;
   height: 3rem;
@@ -4100,9 +4096,9 @@ font-style: normal;
 .product-card-plus .size-options {
   display: none;
   position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
+  top: calc(100% + 0.25rem);
+  right: 0;
+  width: max-content;
   padding: 0.5rem 0.5rem;
   flex-direction: column;
   align-items: stretch;

--- a/assets/swatches-cheyenne.css
+++ b/assets/swatches-cheyenne.css
@@ -9,7 +9,9 @@
 
 .product-card__swatch-indicator {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  align-items: center;
+  width: 100%;
   margin-bottom: 5px; /* Ensure space between swatches and price */
   margin-left: 1px;
   margin-top: -4px;

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -200,21 +200,8 @@
         {% endif %}
       {% endfor %}
     </div>
+
     <div class="swiper-pagination"></div>
-    {% if size_option_index != -1 %}
-      <div class="product-card-plus">
-        <button type="button" class="plus-icon" aria-label="{{ 'products.product.add_to_cart' | t }}" tabindex="0">
-          {{ 'icon-plus.svg' | inline_asset_content }}
-        </button>
-        <div class="size-options" tabindex="-1">
-          <div class="overlay-sizes">
-            {% for size in all_sizes %}
-              <button type="button" class="size-option{% unless available_sizes contains size %} sold-out{% endunless %}" data-size="{{ size }}" {% unless available_sizes contains size %}disabled="disabled"{% endunless %}>{{ size }}</button>
-            {% endfor %}
-          </div>
-        </div>
-      </div>
-    {% endif %}
   </div>
 {% endif %}
 
@@ -288,6 +275,20 @@
                     {% endfor %}
                     {% if additional_swatch_count > 0 %}
                       <span class="additional-swatch-count">+{{ additional_swatch_count }}</span>
+                    {% endif %}
+                    {% if size_option_index != -1 %}
+                      <div class="product-card-plus">
+                        <button type="button" class="plus-icon" aria-label="{{ 'products.product.add_to_cart' | t }}" tabindex="0">
+                          {{ 'icon-plus.svg' | inline_asset_content }}
+                        </button>
+                        <div class="size-options" tabindex="-1">
+                          <div class="overlay-sizes">
+                            {% for size in all_sizes %}
+                              <button type="button" class="size-option{% unless available_sizes contains size %} sold-out{% endunless %}" data-size="{{ size }}" {% unless available_sizes contains size %}disabled="disabled"{% endunless %}>{{ size }}</button>
+                            {% endfor %}
+                          </div>
+                        </div>
+                      </div>
                     {% endif %}
                   </div>
                 {% endif %}


### PR DESCRIPTION
## Summary
- move product quick-add plus icon from image overlay to the right of color swatches
- update styles so size selector dropdown appears relative to swatches

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894859d77508325862792fced04aedd