### PR TITLE
Show low stock message in size quick add

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -4136,11 +4136,21 @@ font-style: normal;
     border-radius: 0%;
     width: 100%;
     text-align: left;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 }
 
 .product-card-plus .size-option.sold-out {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.product-card-plus .low-stock-message {
+  margin-top: 0.25rem;
+  font-size: 1.1rem;
+  color: #d00;
+  display: none;
 }
 
 @media screen and (min-width: 1160px) {

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -411,26 +411,41 @@
           if (selectedColor && colorIndex !== -1 && v.options[colorIndex] != selectedColor) return;
           var sizeVal = v.options[sizeIndex];
           if (!sizeVal) return;
-          if (sizeAvailability[sizeVal] === undefined) {
-            sizeAvailability[sizeVal] = v.available;
-          } else {
-            sizeAvailability[sizeVal] = sizeAvailability[sizeVal] || v.available;
+          var info = sizeAvailability[sizeVal] || { available: false, quantity: null };
+          info.available = info.available || v.available;
+          if (v.inventory_quantity !== null && v.inventory_quantity !== undefined) {
+            info.quantity = v.inventory_quantity;
           }
+          sizeAvailability[sizeVal] = info;
         });
 
         var buttons = card.querySelectorAll('.size-options .size-option');
         buttons.forEach(function(btn) {
           var sizeVal = btn.dataset.size;
-          if (sizeAvailability[sizeVal] === undefined) {
+          var info = sizeAvailability[sizeVal];
+          if (info === undefined) {
             btn.style.display = 'none';
           } else {
             btn.style.display = '';
-            if (sizeAvailability[sizeVal]) {
+            if (info.available) {
               btn.classList.remove('sold-out');
               btn.disabled = false;
             } else {
               btn.classList.add('sold-out');
               btn.disabled = true;
+            }
+            var msg = btn.querySelector('.low-stock-message');
+            if (!msg) {
+              msg = document.createElement('span');
+              msg.className = 'low-stock-message';
+              btn.appendChild(msg);
+            }
+            if (info.available && info.quantity !== null && info.quantity < 5) {
+              msg.textContent = 'Poucas unidades';
+              msg.style.display = 'block';
+            } else {
+              msg.textContent = '';
+              msg.style.display = 'none';
             }
           }
         });


### PR DESCRIPTION
## Summary
- Show "Poucas unidades" message when quick-add size has less than five items in stock
- Style size options and low stock warning in quick add drawer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dfbac0748325adefa0b0ae40478e