### PR TITLE
Add subtle open animation to cart drawer

### DIFF
--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -8,10 +8,16 @@
   display: flex;
   justify-content: flex-end;
   background-color: rgba(var(--color-foreground), 0.5);
-  transition: visibility var(--duration-default) ease;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.drawer.animate {
+  transition: opacity var(--duration-default) ease, visibility var(--duration-default) ease;
 }
 
 .drawer.active {
+  opacity: 1;
   visibility: visible;
 }
 
@@ -26,7 +32,7 @@
   display: flex;
   flex-direction: column;
   transform: translateX(100%);
-  transition: transform var(--duration-default) ease;
+  opacity: 0;
 }
 
 .drawer__inner-empty {
@@ -64,8 +70,13 @@ cart-drawer:not(.is-empty) .cart-drawer__collection {
   margin-top: 2.5rem;
 }
 
+.drawer.animate .drawer__inner {
+  transition: transform var(--duration-default) ease, opacity var(--duration-default) ease;
+}
+
 .drawer.active .drawer__inner {
   transform: translateX(0);
+  opacity: 1;
 }
 
 .drawer__header {

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -14,6 +14,7 @@
 <style>
   .drawer {
     visibility: hidden;
+    opacity: 0;
   }
 </style>
 


### PR DESCRIPTION
## Summary
- fade in cart drawer overlay and content with animated slide
- ensure drawer starts hidden to prevent flash during load

## Testing
- `npm test` *(fails: missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_689608af427c8325918c6c8363952ebf