### PR TITLE
feat: resize mobile logo on inner pages

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -109,6 +109,16 @@ body.menu-drawer-open .nav-menu-new a.active::after {
       fill: currentColor;
       stroke: currentColor;
     }
+    @media screen and (max-width: 749px) {
+      .header__heading-link {
+        display: flex;
+        align-items: center;
+      }
+      .header__heading-logo {
+        max-height: 35px;
+        width: auto;
+      }
+    }
     {% endif %}
   
   header-drawer {


### PR DESCRIPTION
## Summary
- shrink logo on mobile for non-home pages and align with header icons

## Testing
- `npx @shopify/theme-check@latest` *(fails: 404 Not Found - GET https://registry.npmjs.org/@shopify%2ftheme-check)*
- `npx theme-check` *(fails: could not determine executable to run)*
- `shopify theme check` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be99aecb1c8325b83cf6e119ba2191