### PR TITLE
feat: resize mobile logo on inner pages

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -92,10 +92,6 @@ body.menu-drawer-open .nav-menu-new a.active::after {
       position: absolute !important;
       width: 100% !important;
       top: 0px;
-
-      /*  NEW LINE OF CODE STARTS */
-
-      /*  NEW LINE OF CODE ENDS*/
     }
        {% else %}
 
@@ -108,6 +104,18 @@ body.menu-drawer-open .nav-menu-new a.active::after {
     .header__icon svg {
       fill: currentColor;
       stroke: currentColor;
+    }
+    @media screen and (max-width: 749px) {
+      .header__heading-link {
+        display: flex;
+        align-items: center;
+        height: 100%;
+      }
+      .header__heading-logo {
+        height: 35px;
+        width: auto;
+        display: block;
+      }
     }
     {% endif %}
   


### PR DESCRIPTION
## Summary
- shrink logo on mobile for non-home pages and align with header icons
- ensure logo remains visible by setting explicit height and display on small screens

## Testing
- `npx @shopify/theme-check@latest` *(fails: 404 Not Found - GET https://registry.npmjs.org/@shopify%2ftheme-check)*
- `npx theme-check` *(fails: could not determine executable to run)*
- `shopify theme check` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be99aecb1c8325b83cf6e119ba2191