### PR TITLE
feat: resize mobile logo on inner pages

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -92,10 +92,6 @@ body.menu-drawer-open .nav-menu-new a.active::after {
       position: absolute !important;
       width: 100% !important;
       top: 0px;
-
-      /*  NEW LINE OF CODE STARTS */
-
-      /*  NEW LINE OF CODE ENDS*/
     }
        {% else %}
 
@@ -108,6 +104,47 @@ body.menu-drawer-open .nav-menu-new a.active::after {
     .header__icon svg {
       fill: currentColor;
       stroke: currentColor;
+    }
+    @media screen and (max-width: 749px) {
+      .header {
+        grid-template-columns: auto 1fr auto;
+        grid-template-rows: auto;
+        grid-template-areas: 'left-icons heading icons';
+        align-items: center;
+        gap: 0;
+        padding: 1rem 0;
+      }
+      .header__heading,
+      .header__heading-link {
+        grid-area: heading;
+        grid-column: 2;
+        grid-row: 1;
+        justify-self: center;
+      }
+      .header__icons {
+        grid-area: icons;
+        grid-column: 3;
+        grid-row: 1;
+        justify-self: end;
+        padding-right: 0;
+      }
+      .header > .header__search,
+      .header__icon--menu {
+        grid-area: left-icons;
+        grid-column: 1;
+        grid-row: 1;
+        justify-self: start;
+      }
+      .header__heading-link {
+        display: flex;
+        align-items: center;
+        height: 100%;
+      }
+      .header__heading-logo {
+        height: 35px;
+        width: auto;
+        display: block;
+      }
     }
     {% endif %}
   


### PR DESCRIPTION
## Summary
- shrink logo on mobile for non-home pages and align with header icons
- ensure logo remains visible by setting explicit height and display on small screens

## Testing
- `npx @shopify/theme-check@latest` *(fails: 404 Not Found - GET https://registry.npmjs.org/@shopify%2ftheme-check)*
- `npx theme-check` *(fails: could not determine executable to run)*
- `shopify theme check` *(fails: 186 errors, 67 warnings)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be99aecb1c8325b83cf6e119ba2191