### PR TITLE
feat: resize mobile logo on inner pages

### DIFF
--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -92,10 +92,6 @@ body.menu-drawer-open .nav-menu-new a.active::after {
       position: absolute !important;
       width: 100% !important;
       top: 0px;
-
-      /*  NEW LINE OF CODE STARTS */
-
-      /*  NEW LINE OF CODE ENDS*/
     }
        {% else %}
 
@@ -108,6 +104,37 @@ body.menu-drawer-open .nav-menu-new a.active::after {
     .header__icon svg {
       fill: currentColor;
       stroke: currentColor;
+    }
+    @media screen and (max-width: 749px) {
+      .header {
+        display: flex;
+        align-items: center;
+        padding: 1rem 0;
+      }
+      header-drawer {
+        margin-right: 1rem;
+      }
+      .header__heading,
+      .header__heading-link {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+      }
+      .header__icons {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-left: auto;
+        padding-right: 0;
+      }
+      .header > .header__search {
+        display: none;
+      }
+      .header__heading-logo {
+        height: 35px;
+        width: auto;
+        display: block;
+      }
     }
     {% endif %}
   


### PR DESCRIPTION
## Summary
- switch non-index mobile header layout to flex so hamburger, logo and utility icons share one row
- hide standalone mobile search and keep logo constrained to 35px height

## Testing
- `npx @shopify/theme-check@latest` *(fails: 404 Not Found - GET https://registry.npmjs.org/@shopify%2ftheme-check)*
- `npx theme-check` *(fails: could not determine executable to run)*
- `shopify theme check` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be99aecb1c8325b83cf6e119ba2191