### PR TITLE
feat: redesign mobile sticky product bar

### DIFF
--- a/sections/sticky-product-bar.liquid
+++ b/sections/sticky-product-bar.liquid
@@ -3,869 +3,144 @@
   "name": "Sticky Product Bar",
   "settings": [],
   "presets": [
-    {
-      "name": "Sticky Product Bar"
-    }
+    { "name": "Sticky Product Bar" }
   ]
 }
 {% endschema %}
 
-{% comment %} Create a dummy block object with default settings {% endcomment %}
-{% assign dummy_block = '{ "settings": { "picker_type": "button", "swatch_shape": "circle" }, "shopify_attributes": "" }' | parse_json %}
-
-{% unless product.has_only_default_variant %}
-  {{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
-  {{ 'component-swatch.css' | asset_url | stylesheet_tag }}
-  {{ 'swatches-cheyenne.css' | asset_url | stylesheet_tag }}
-{% endunless %}
 {{ 'component-swatch-input.css' | asset_url | stylesheet_tag }}
-{{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
 {{ 'component-swatch.css' | asset_url | stylesheet_tag }}
-{{ 'swatches-cheyenne.css' | asset_url | stylesheet_tag }}
+
+<div id="sticky-product-bar" class="sticky-bar">
+  <div class="sticky-bar-inner">
+    <div class="product-title">{{ product.title }}</div>
+    <div class="product-price" id="sticky-price">
+      {% render 'price', product: product, show_badges: true %}
+    </div>
+    {% assign color_option = product.options_with_values | where: 'name', 'Color' | first %}
+    {% if color_option %}
+    <div class="color-swatches">
+      {% for value in color_option.values %}
+        {% assign id = 'sticky-color-' | append: forloop.index %}
+        <label class="swatch-input__wrapper">
+          <input type="radio" name="sticky-color" id="{{ id }}" value="{{ value | escape }}" class="visually-hidden">
+          {% render 'swatch', swatch: value.swatch, option_value: value %}
+        </label>
+      {% endfor %}
+    </div>
+    {% endif %}
+    <button id="sticky-add" class="button button--primary" {% if color_option %}disabled{% endif %}>{{ 'products.product.add_to_cart' | t }}</button>
+  </div>
+</div>
+
+<div id="size-drawer" class="size-drawer">
+  <div class="drawer-overlay"></div>
+  <div class="drawer-panel">
+    <button type="button" class="drawer-close" aria-label="Close">&times;</button>
+    <h3>Select size</h3>
+    <div class="size-options"></div>
+  </div>
+</div>
+
+<script>
+var productData = {{ product | json }};
+var colorOptionIndex = productData.options.findIndex(function(o){ return o.name.toLowerCase() === 'color'; });
+var sizeOptionIndex = productData.options.findIndex(function(o){ return o.name.toLowerCase() === 'size'; });
+var selectedColor = null;
+var addBtn = document.getElementById('sticky-add');
+
+if(colorOptionIndex !== -1){
+  document.querySelectorAll('input[name="sticky-color"]').forEach(function(el){
+    el.addEventListener('change', function(){
+      selectedColor = this.value;
+      addBtn.disabled = false;
+      updatePrice();
+    });
+  });
+}
+
+addBtn.addEventListener('click', function(){
+  if(sizeOptionIndex !== -1){
+    openSizeDrawer();
+  } else {
+    var variant = getVariant(selectedColor, null) || productData.variants[0];
+    addVariantToCart(variant.id);
+  }
+});
+
+document.querySelector('#size-drawer .drawer-overlay').addEventListener('click', closeSizeDrawer);
+document.querySelector('#size-drawer .drawer-close').addEventListener('click', closeSizeDrawer);
+
+function openSizeDrawer(){
+  var drawer = document.getElementById('size-drawer');
+  var container = drawer.querySelector('.size-options');
+  container.innerHTML = '';
+  var sizes = [];
+  productData.variants.forEach(function(v){
+    if(colorOptionIndex === -1 || v.options[colorOptionIndex] === selectedColor){
+      var size = v.options[sizeOptionIndex];
+      if(sizes.indexOf(size) === -1 && v.available){ sizes.push(size); }
+    }
+  });
+  sizes.forEach(function(size){
+    var btn = document.createElement('button');
+    btn.className = 'size-option button button--primary';
+    btn.textContent = size;
+    btn.addEventListener('click', function(){
+      var variant = getVariant(selectedColor, size);
+      if(variant){
+        addVariantToCart(variant.id);
+        closeSizeDrawer();
+      }
+    });
+    container.appendChild(btn);
+  });
+  drawer.classList.add('open');
+}
+
+function closeSizeDrawer(){
+  document.getElementById('size-drawer').classList.remove('open');
+}
+
+function getVariant(color, size){
+  return productData.variants.find(function(v){
+    var match = true;
+    if(colorOptionIndex !== -1 && color) match = match && v.options[colorOptionIndex] === color;
+    if(sizeOptionIndex !== -1 && size) match = match && v.options[sizeOptionIndex] === size;
+    return match;
+  });
+}
+
+function addVariantToCart(variantId){
+  fetch('/cart/add.js', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: variantId, quantity: 1 })
+  }).then(function(){ window.location.href = '/cart'; });
+}
+
+function updatePrice(){
+  var variant = getVariant(selectedColor, null);
+  if(variant){
+    var priceEl = document.getElementById('sticky-price');
+    var price = Shopify.formatMoney(variant.price, window.Shopify.currency);
+    var compare = variant.compare_at_price && variant.compare_at_price > variant.price ? Shopify.formatMoney(variant.compare_at_price, window.Shopify.currency) : null;
+    priceEl.innerHTML = compare ? '<span class="price-item price-item--regular"><s>' + compare + '</s></span> <span class="price-item price-item--sale">' + price + '</span>' : price;
+  }
+}
+</script>
 
 <style>
-
-@media (min-width: 750px) {
-  #sticky-product-bar {
-    display: none;
-  }
-}
-  
-@media (max-width: 749px) {
-/* Sticky Product Bar Outer Container */
-#sticky-product-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  background-color: #ffffff;
-  box-shadow: 0 -1px 15px rgba(0, 0, 0, 0.1);
-  transform: translateY(0);
-  transition: transform 0.25s ease;
-  height: auto; /* Static height */
-  overflow: visible;
-  z-index: 1000;
-  cursor: default;
-}
-
-.sticky-bar-inner {
-  height: auto;
-  overflow: hidden;
-}
-
-.drawer-content {
-  display: none !important; /* Hide all non-essential drawer content */
-}
-
-/* Small “grab” bar indicator */
-#sticky-product-bar::before { display: none; }
-
-/* Ensure any internal size-chart, related, footer blocks are hidden */
-#sticky-product-bar .size-chart,
-#sticky-product-bar .mobile-related-products,
-#sticky-product-bar .drawer-footer { display: none !important; }
-
-/* Hidden state when recommendations are visible */
-#sticky-product-bar.is-hidden-by-recs { transform: translateY(110%); pointer-events: none; }
-
-/* Variant label adjustments */
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > div > label {
-  display: none;
-}
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--pill > legend {
-  display: none;
-}
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--swatch > label {
-  margin-top: 8px;
-  margin-left: 1px;
-  margin-right: 10px;
-}
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--pill {
-  margin-top: 4px;
-}
-.product-form__input--pill input[type=radio] + label {
-  border-radius: 0% !important;
-}
-
-/* Layout/spacing tweaks */
-#sticky-product-bar > .sticky-bar-inner > div.sticky-bar-summary {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-top: 3px;
-}
-#ProductSubmitButton- {
-  margin-top: -7px;
-}
-
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--swatch,
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--pill {
-  margin-inline: 0px!important;
-}
-#sticky-product-bar > div > div > div.sticky-bar-summary > div.product-title {
-    font-family: "Figtree", Arial, Helvetica, sans-serif;
-    font-weight: normal;
-    font-size: 1.6rem;
-    line-height: 2.2rem;
-    text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: black;
-    margin-left: 5%;
-    margin-top: 8px;
-}
-
-/* Variant picker layout */
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  width: 100%;
-  margin-top: 9px;
-  gap: 2%;
-}
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > div:nth-child(1) > div > span.dropdown-swatch > span {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-}
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > div {
-  width: 44%;
-}
-#variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > div > div > span.svg-wrapper {
-  margin-right: 10px;
-}
-
-/* Price styling */
-#sticky-product-bar > div > div > div.sticky-bar-summary > div.price_variants > div.product-price > div > div > div.price__sale {
-  background-color: transparent;
-}
-#sticky-product-bar > div > div > div.sticky-bar-summary > div.price_variants > div.product-price > div {
-  font-weight: bold!important;
-  font-size: 15px!important;
-  margin-left: 5%;
-}
-#sticky-product-bar > div.sticky-bar-inner > div > div.sticky-bar-summary > div.price_variants
-  > div.product-price > div > div > div.price__sale > span.price-item.price-item--sale.price-item--last {
-  color: #ff6f61;
-  font-weight: bold;
-}
-
-  }
-
-
-@media (min-width: 748px) { 
-#sticky-product-bar > div.drawer-content > div.drawer-footer > footer > div.footer__content-top.page-width > div.mobile-menu > nav {
-  display:none;
-}
-  }
-
-
-.#sticky-product-bar > div.drawer-content > div.drawer-footer > footer {
-  padding: 0px;
-  background-color: fff; /* Light background for contrast */
-}
-
-
-
-#sticky-product-bar > div.drawer-content > div.mobile-related-products {
-  margin-left: 0px;
-  margin-right: 0px;
-  margin-top: 70px!important;
-}
-
-
-  #sticky-product-bar > div.drawer-content > div.mobile-related-products > h2 {
-    margin-left: 10%!important;
-  }
-
-  #sticky-product-bar > div.drawer-content > div.drawer-footer > footer > div.footer__content-top.page-width > div.mobile-menu > nav {
-    padding: 0px!important;
-  }
-
-  #sticky-product-bar > div.drawer-content > div.drawer-footer > footer > div.footer__content-top.page-width {
-    margin: 0px;
-  }
-
-  .footer__content-top {
-    padding-bottom: 5rem!important;
-}
-
-  .footer-block--newsletter {
-    margin-bottom: 70px;
-}
-
-  #sticky-product-bar > div.drawer-content > div.drawer-footer > footer > div.footer__content-top.page-width > div.mobile-menu {
-    margin-top: 30px;
-  }
-
-.drawer-content .accordion-content {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-
-.drawer-content .accordion-button,
-.drawer-content .accordion-content {
-  pointer-events: auto;
-}
-
-  .drawer-modal {
-  display: none; /* Hidden by default */
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.5); /* Semi-transparent overlay */
-  z-index: 2000; /* Ensure it's on top */
-}
-
-.drawer-modal-content {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: #fff;
-    padding: 20px;
-    border-radius: 4px;
-    max-width: 100%;
-    max-height: 80%;
-    width: 95%;
-    height: 80%;
-    overflow-y: auto;
-}
-
-.drawer-close {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-}
-
-.size-chart {
-  margin-top: 10px;
-  margin-left: 4%;
-  margin-bottom: 6px;
-
-}
+#sticky-product-bar{position:fixed;bottom:0;left:0;width:100%;background:#fff;box-shadow:0 -1px 10px rgba(0,0,0,0.1);padding:10px;display:flex;align-items:center;gap:10px;z-index:1000;}
+#sticky-product-bar .product-title{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-weight:bold;}
+.color-swatches{display:flex;gap:4px;}
+.color-swatches .swatch{cursor:pointer;}
+#sticky-add{flex-shrink:0;}
+#size-drawer{display:none;position:fixed;top:0;left:0;right:0;bottom:0;z-index:1100;}
+#size-drawer.open{display:block;}
+#size-drawer .drawer-overlay{position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);}
+#size-drawer .drawer-panel{position:absolute;bottom:0;left:0;right:0;background:#fff;padding:20px;border-radius:8px 8px 0 0;max-height:80%;overflow-y:auto;}
+#size-drawer .drawer-close{position:absolute;top:10px;right:10px;background:none;border:none;font-size:1.5rem;}
+#size-drawer .size-option{width:100%;margin:5px 0;}
+@media(min-width:750px){#sticky-product-bar{display:none;}}
 </style>
-
-<!-- Provide the product data in JSON -->
-<script>
-  var productData = {{ product | json }};
-</script>
-
-<!-- Sticky Product Bar Container -->
-<div id="sticky-product-bar" class="sticky-bar" aria-expanded="false">
-  <div class="sticky-bar-inner">
-    <div class="sticky-bar-header">
-      <!-- Left side: Title, Price, Variant Picker -->
-      <div class="sticky-bar-summary">
-        <div class="product-title">
-          {{ product.title }}
-        </div>
-        <div class="price_variants">
-          <div class="product-price">
-            {% render 'price', product: product, use_variant: true, show_badges: true %}
-          </div>
-          {% unless product.has_only_default_variant %}
-          <div class="product-variants">
-            {% render 'product-variant-picker', product: product, block: dummy_block, product_form_id: 'product-form-' | append: section.id %}
-          </div>
-          {% endunless %}
-        </div>
-      </div>
-      <!-- Right side: Add to Cart button(s) -->
-      <div class="add-to-cart">
-        {% render 'buy-buttons',
-            block: dummy_block,
-            product: product,
-            product_form_id: 'product-form-' | append: section.id,
-            show_pickup_availability: false
-        %}
-      </div>
-    </div>
-  </div>
-  <div class="size-chart">
-  {% render 'size-chart' %}
-    </div>
-  <!-- Drawer Content -->
-  <div class="drawer-content" style="background: #fff;">
-    <div class="drawer-description" style="color: #333; font-size: 14px; line-height: 1.5; margin-left: 5%; margin-right: 5%; margin-top: 4rem;">
-      {{ product.content }}
-    </div>
-
-  <!-- Accordion: Added below the product description -->
-  <div class="product-info-accordion" style="margin: 5rem 5%; z-index:1000;">
-    <div class="accordion-item">
-      <button class="accordion-button" aria-expanded="false">
-        Composição e cuidados
-      </button>
-      <div class="accordion-content">
-        <p>
-          Exemplo: 100% Algodão. Lavar à máquina a 30°C.
-        </p>
-      </div>
-    </div>
-
-    <div class="accordion-item">
-      <button class="accordion-button" aria-expanded="false">
-        Envios, trocas e devoluções
-      </button>
-      <div class="accordion-content">
-        <!-- <p>
-          Exemplo: Entrega em 2-3 dias úteis. Trocas e devoluções até 30 dias.
-        </p> --> 
-      </div>
-    </div>
-
-    <div class="accordion-item">
-      <button class="accordion-button" aria-expanded="false">
-        Disponibilidade na loja
-      </button>
-      <div class="accordion-content">
-        <p>
-          Exemplo: Disponível em todas as lojas da região.
-        </p>
-      </div>
-    </div>
-
-    <div class="accordion-item">
-      <button class="accordion-button" aria-expanded="false">
-        Partilhar
-      </button>
-      <div class="accordion-content">
-        <p>
-          <a href="#">Facebook</a> | <a href="#">Instagram</a> | <a href="#">Twitter</a>
-        </p>
-      </div>
-    </div>
-  </div>
-    
-    <!-- DRAWER MARKUP: Place this outside the sticky bar, typically near the bottom of the body -->
-<div id="envios-drawer" class="drawer-modal">
-  <div class="drawer-modal-content">
-    <!-- Close Button -->
-    <button class="drawer-close" aria-label="Close">&times;</button>
-
-    <!-- Drawer Body -->
-    <div class="drawer-modal-body">
-
-      <!-- MÉTODOS DE ENVIO -->
-      <h3>MÉTODOS DE ENVIO</h3>
-      <ul>
-        <li>Recolha na loja <strong>GRÁTIS</strong>.</li>
-        <li>Envio para o ponto de entrega <strong>3,99 €</strong></li>
-        <li>Envio normal <strong>4,99 €</strong></li>
-        <li>Envio normal (Açores e Madeira) <strong>29,99 €</strong></li>
-      </ul>
-
-      <!-- TROCAS E DEVOLUÇÕES -->
-      <h3>TROCAS E DEVOLUÇÕES</h3>
-      <p>
-        Podes devolver um artigo até 30 dias após receberes o e-mail de confirmação de envio da tua encomenda.
-      </p>
-
-      <!-- TROCAS -->
-      <h3>TROCAS</h3>
-      <ul>
-        <li>Na loja Lefties – <strong>GRÁTIS</strong></li>
-        <li>
-          Artigos comprados em Cheyenne.pt podem ser trocados por outros de tamanho ou cor diferentes, em qualquer loja Cheyenne, desde que haja disponibilidade.
-        </li>
-        <li>
-          Também podes efetuar a troca através de Cheyenne.pt. Após a verificação do estado do artigo, enviamos o novo produto de substituição.
-        </li>
-      </ul>
-
-      <!-- DEVOLUÇÕES -->
-      <h3>DEVOLUÇÕES</h3>
-      <ul>
-        <li>Na loja – <strong>GRÁTIS</strong></li>
-        <li>Pela Cheyenne.pt - <strong>1,99 €</strong></li>
-        <li>
-          Para ver os pontos de entrega disponíveis, clique 
-          <a href="#">[AQUI]</a>
-        </li>
-      </ul>
-
-    </div>
-  </div>
-</div>
-
-
-    <div class="mobile-related-products">
-      <h2 class="also" style="margin-bottom: 1em;">Talvez lhe possa interessar</h2>
-      {% render 'random-collection-grid' %}
-    </div>
-    <div class="drawer-footer" style="margin-top: 20px;">
-      {% render 'footer-drawer' %}
-    </div>
-  </div>
-</div>
-
-
-<!-- JS for sticky bar drag + momentum + recalc/clamp -->
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  const stickyBar = document.getElementById('sticky-product-bar');
-  
-  // Disable default touch actions so pointer events work reliably.
-  stickyBar.style.touchAction = 'none';
-  
-  const minHeight = 195; // Collapsed height
-  let maxHeight = stickyBar.scrollHeight; // Current "expanded" height
-
-  let startY = 0;
-  let startHeight = 0;
-  let dragging = false;
-  
-  // For velocity-based momentum
-  let lastY = 0;
-  let lastTime = 0;
-  let velocity = 0;
-
-  // ---------- ORIGINAL “SWIPE FEEL” VALUES ----------
-  const dragMultiplier = 1.5; // (Reverted to your original value)
-  const deceleration = 0.0025; // (Reverted to your original value)
-
-  // --------------------------
-  // HELPER: Recalc/Clamp Height
-  // --------------------------
-  function recalcMaxHeight() {
-    const newMaxHeight = stickyBar.scrollHeight;
-    const currentHeight = stickyBar.offsetHeight;
-    
-    maxHeight = newMaxHeight;
-    
-    // If the bar is now taller than content (e.g. dropdown was closed),
-    // clamp it so no blank space remains.
-    if (currentHeight > newMaxHeight) {
-      stickyBar.style.height = newMaxHeight + 'px';
-    } else {
-      // If the bar was basically at old max, keep it at new max
-      if (Math.abs(currentHeight - maxHeight) < 2) {
-        stickyBar.style.height = newMaxHeight + 'px';
-      }
-    }
-  }
-
-  // --------------------------
-  // MOMENTUM ANIMATION
-  // --------------------------
-  function animateMomentum(initialVelocity) {
-    let currentHeight = stickyBar.offsetHeight;
-    let v = initialVelocity;
-    let previousTime = performance.now();
-    
-    function step(currentTime) {
-      const dt = currentTime - previousTime;
-      previousTime = currentTime;
-      
-      currentHeight += v * dt;
-      
-      // Apply deceleration
-      if (v > 0) {
-        v -= deceleration * dt;
-        if (v < 0) v = 0;
-      } else if (v < 0) {
-        v += deceleration * dt;
-        if (v > 0) v = 0;
-      }
-      
-      // Clamp to min/max
-      if (currentHeight < minHeight) {
-        currentHeight = minHeight;
-        v = 0;
-      } else if (currentHeight > maxHeight) {
-        currentHeight = maxHeight;
-        v = 0;
-      }
-      
-      stickyBar.style.height = currentHeight + 'px';
-      
-      // Continue if velocity remains
-      if (Math.abs(v) > 0.01) {
-        requestAnimationFrame(step);
-      } else {
-        // Snap to nearest if close
-        const snapThreshold = 50;
-        if (currentHeight - minHeight < snapThreshold) {
-          stickyBar.style.height = minHeight + 'px';
-        } else if (maxHeight - currentHeight < snapThreshold) {
-          stickyBar.style.height = maxHeight + 'px';
-        }
-      }
-    }
-    
-    requestAnimationFrame(step);
-  }
-  
-  // --------------------------
-  // POINTER EVENTS FOR DRAG
-  // --------------------------
-stickyBar.addEventListener('pointerdown', function(e) {
-  // If the click starts on an accordion button or its content, do nothing
-  if (e.target.closest('.accordion-button') || e.target.closest('.accordion-content')) {
-    return;
-  }
-  
-  // Exclude <select> or custom dropdowns from dragging
- if (e.target.closest('.custom-dropdown')) {
-  return;
-}
-  
-  e.preventDefault();
-  
-  startY = e.clientY;
-  startHeight = stickyBar.offsetHeight;
-  dragging = true;
-  stickyBar.style.transition = 'none';
-  stickyBar.setPointerCapture(e.pointerId);
-  
-  // Initialize velocity tracking
-  lastY = e.clientY;
-  lastTime = performance.now();
-  velocity = 0;
-
-  // Also recalc if content changed
-  maxHeight = stickyBar.scrollHeight;
-});
-  
-  stickyBar.addEventListener('pointermove', function(e) {
-    if (!dragging) return;
-    
-    const now = performance.now();
-    const dt = now - lastTime;
-    
-    if (dt > 0) {
-      velocity = ((lastY - e.clientY) * dragMultiplier) / dt;
-    }
-    lastY = e.clientY;
-    lastTime = now;
-    
-    const deltaY = (startY - e.clientY) * dragMultiplier;
-    let newHeight = startHeight + deltaY;
-    
-    // Clamp to min/max
-    newHeight = Math.max(minHeight, Math.min(maxHeight, newHeight));
-    stickyBar.style.height = newHeight + 'px';
-  });
-  
-  stickyBar.addEventListener('pointerup', function(e) {
-    if (!dragging) return;
-    dragging = false;
-    stickyBar.releasePointerCapture(e.pointerId);
-    
-    // If velocity is significant, fling
-    if (Math.abs(velocity) > 0.1) {
-      animateMomentum(velocity);
-    } else {
-      // Snap to min or max if close
-      const currentHeight = stickyBar.offsetHeight;
-      const snapThreshold = 50;
-      if (currentHeight - minHeight < snapThreshold) {
-        stickyBar.style.height = minHeight + 'px';
-      } else if (maxHeight - currentHeight < snapThreshold) {
-        stickyBar.style.height = maxHeight + 'px';
-      }
-    }
-  });
-  
-  // Prevent pointer events from interfering with <select> usage
-  document.querySelectorAll('select').forEach(function(selectEl) {
-    selectEl.addEventListener('pointerdown', function(e) {
-      e.stopPropagation();
-    });
-  });
-
-  // --------------------------
-  // LISTEN FOR SUBMENU OPEN/CLOSE
-  // --------------------------
-  // We'll re-measure the bar after each toggle,
-  // to clamp or expand as needed.
-  const dropdownLinks = document.querySelectorAll('.mobile-menu .has-submenu > a.menu-link');
-  dropdownLinks.forEach(link => {
-    link.addEventListener('click', function() {
-      // Let your existing code open/close the dropdown,
-      // then recalc/clamp after a short delay
-      setTimeout(() => {
-        recalcMaxHeight();
-      }, 300);
-    });
-  });
-});
-</script>
-
-
-<!-- Variant ID Sync Script -->
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  if (typeof productData === 'undefined' || !productData.variants) {
-    console.warn("productData not found or has no variants");
-    return;
-  }
-  
-  const buyButtonsForm = document.querySelector('#sticky-product-bar .add-to-cart form');
-  if (!buyButtonsForm) {
-    console.warn("No buy-buttons form found within .add-to-cart");
-    return;
-  }
-  
-  const hiddenInput = buyButtonsForm.querySelector('input[name="id"]');
-  if (!hiddenInput) {
-    console.warn("No hidden input[name='id'] found in buy-buttons form");
-    return;
-  }
-  
-  const variantPickerEl = document.getElementById('variant-selects-{{ section.id }}');
-  if (!variantPickerEl) {
-    console.warn("No variant-picker element found with id: variant-selects-{{ section.id }}");
-    return;
-  }
-  
-  const optionInputs = variantPickerEl.querySelectorAll('input[name^="options"], select[name^="options"]');
-  if (!optionInputs.length) {
-    console.warn("No variant option inputs found in variant-picker");
-    return;
-  }
-
-  function getSelectedOptions() {
-    const selected = [];
-    optionInputs.forEach(input => {
-      if (input.tagName.toLowerCase() === 'select' && input.value === "") {
-        selected.push(null);
-      } else {
-        selected.push(input.value.trim());
-      }
-    });
-    return selected;
-  }
-
-  function findVariant(selectedOptions) {
-    return productData.variants.find(variant => {
-      return variant.options.every((opt, idx) => {
-        return String(selectedOptions[idx]).toLowerCase() === String(opt).toLowerCase();
-      });
-    });
-  }
-
-  function updateVariant() {
-    const selectedOptions = getSelectedOptions();
-    const matchingVariant = findVariant(selectedOptions);
-    if (matchingVariant) {
-      hiddenInput.value = matchingVariant.id;
-      hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
-    } else {
-      console.warn("No matching variant found for options:", selectedOptions);
-    }
-  }
-
-  // Listen for changes to variant picker
-  optionInputs.forEach(input => {
-    input.addEventListener('change', updateVariant);
-  });
-});
-</script>
-
-{% raw %}
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  console.log("Sticky bar variant scroll script loaded");
-
-  // Find the sticky variant picker.
-  var variantPicker = document.querySelector('[id^="variant-selects-template"][id*="sticky_product_bar"]');
-  if (!variantPicker) {
-    console.log("Sticky variant picker not found");
-    return;
-  }
-  console.log("Sticky variant picker found:", variantPicker.id);
-
-  // Listen for changes on any input/select within the variant picker.
-  variantPicker.addEventListener('change', function(e) {
-    console.log("Change event fired on sticky variant picker", e);
-
-    // Gather selected options from the picker.
-    var selectedOptions = [];
-    variantPicker.querySelectorAll('input[name^="options"], select[name^="options"]').forEach(function(input) {
-      selectedOptions.push(input.value.trim());
-    });
-    console.log("Selected options:", selectedOptions);
-
-    // Find the matching variant using the productData object.
-    var matchingVariant = productData.variants.find(function(variant) {
-      return variant.options.every(function(opt, idx) {
-        return String(opt).toLowerCase() === selectedOptions[idx].toLowerCase();
-      });
-    });
-    if (matchingVariant) {
-      console.log("Matching variant found:", matchingVariant);
-      if (matchingVariant.featured_media && matchingVariant.featured_media.id) {
-        // Find the media gallery element.
-        var galleryEl = document.querySelector('[id^="MediaGallery-"]');
-        if (!galleryEl) {
-          console.log("Gallery element not found");
-          return;
-        }
-        console.log("Gallery element found:", galleryEl.id);
-
-        // Instead of splitting the id, remove the prefix "MediaGallery-"
-        var sectionId = galleryEl.id.replace('MediaGallery-', '');
-        console.log("Extracted sectionId:", sectionId);
-
-        // Construct the target media id that should match the data-media-id attribute.
-        var targetMediaId = sectionId + '-' + matchingVariant.featured_media.id;
-        console.log("Looking for media element with data-media-id:", targetMediaId);
-
-        // Locate the media element.
-        var mediaEl = document.querySelector('[data-media-id="' + targetMediaId + '"]');
-        if (mediaEl) {
-          console.log("Found media element, scrolling into view", mediaEl);
-          mediaEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        } else {
-          console.log("No matching media element found for", targetMediaId);
-        }
-      } else {
-        console.log("Matching variant does not have a featured_media property", matchingVariant);
-      }
-    } else {
-      console.log("No matching variant found for options", selectedOptions);
-    }
-  });
-});
-</script>
-{% endraw %}
-
-<!-- Hide sticky bar when recommendations become visible -->
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const sticky = document.getElementById('sticky-product-bar');
-    if (!sticky) return;
-
-    const targets = Array.from(
-      document.querySelectorAll(
-        'product-recommendations.related-products, product-recommendations.complementary-products, .mobile-related-products'
-      )
-    );
-    if (!targets.length) return;
-
-    const update = () => {
-      const vh = window.innerHeight || document.documentElement.clientHeight;
-      const bandTop = vh * 0.15, bandBottom = vh * 0.85;
-      const onScreen = targets.some(el => {
-        const r = el.getBoundingClientRect();
-        return r.top < bandBottom && r.bottom > bandTop;
-      });
-      sticky.classList.toggle('is-hidden-by-recs', onScreen);
-    };
-
-    const io = new IntersectionObserver(update, { threshold: [0, 0.1, 0.25, 0.5] });
-    targets.forEach(t => io.observe(t));
-    window.addEventListener('scroll', update, { passive: true });
-    window.addEventListener('resize', update);
-    update();
-  });
-</script>
-
-<!-- General Accordion Toggle (Click) -->
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  const accordionButtons = document.querySelectorAll('.drawer-content .accordion-button');
-  accordionButtons.forEach((button) => {
-    // Skip the Envios button so its toggling is handled separately.
-    if (button.textContent.trim() === "Envios, trocas e devoluções") return;
-    
-    button.addEventListener('click', (e) => {
-      // Prevent interference from sticky bar drag
-      e.stopPropagation();
-      const expanded = button.getAttribute('aria-expanded') === 'true';
-      button.setAttribute('aria-expanded', !expanded);
-      const content = button.nextElementSibling;
-      if (content) {
-        if (expanded) {
-          content.style.maxHeight = null;
-        } else {
-          content.style.maxHeight = content.scrollHeight + 'px';
-        }
-      }
-    });
-  });
-});
-</script>
-
-<!-- General Accordion Toggle (Pointerup) -->
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  document.querySelectorAll('.drawer-content .accordion-button').forEach((button) => {
-    // Skip the Envios button so its toggling is handled separately.
-    if (button.textContent.trim() === "Envios, trocas e devoluções") return;
-    
-    button.addEventListener('pointerup', (e) => {
-      e.stopPropagation();
-      const expanded = button.getAttribute('aria-expanded') === 'true';
-      button.setAttribute('aria-expanded', !expanded);
-      const content = button.nextElementSibling;
-      if (content) {
-        if (expanded) {
-          content.style.maxHeight = null;
-        } else {
-          content.style.maxHeight = content.scrollHeight + 'px';
-        }
-      }
-    });
-  });
-});
-</script>
-
-<!-- Override for "Envios, trocas e devoluções" to open a drawer only -->
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  // Locate the Envios button by its exact text content.
-  const envioButton = Array.from(document.querySelectorAll('.accordion-button'))
-    .find(btn => btn.textContent.trim() === "Envios, trocas e devoluções");
-
-  if (envioButton) {
-    // Override the default behavior on click.
-    envioButton.addEventListener('click', function(e) {
-      e.preventDefault();
-      e.stopPropagation();
-      e.stopImmediatePropagation(); // Block any further click handlers
-      
-      // Force closed state on the accordion item.
-      envioButton.setAttribute('aria-expanded', 'false');
-      const content = envioButton.nextElementSibling;
-      if (content) {
-         content.style.maxHeight = null;
-      }
-      
-      // Open the custom centered drawer.
-      const drawer = document.getElementById('envios-drawer');
-      if (drawer) {
-        drawer.style.display = 'block';
-      }
-    }, true); // Using the capture phase
-
-    // Also override pointerup so no toggling occurs.
-    envioButton.addEventListener('pointerup', function(e) {
-      e.preventDefault();
-      e.stopPropagation();
-      e.stopImmediatePropagation();
-    }, true);
-  }
-
-  // Drawer close logic: click on overlay or close button.
-  const enviosDrawer = document.getElementById('envios-drawer');
-  if (enviosDrawer) {
-    enviosDrawer.addEventListener('click', function(e) {
-      if (e.target === enviosDrawer || e.target.classList.contains('drawer-close')) {
-        enviosDrawer.style.display = 'none';
-      }
-    });
-  }
-});
-</script>
-


### PR DESCRIPTION
## Summary
- Simplify sticky bar for mobile with product title, price and color swatches
- Add single primary button that opens size picker drawer when needed
- Handle variant selection and cart submission via JS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `shopify theme check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00e7a14c08325b2d4472fd8a8692d