### PR TITLE
Ensure quick-add icon aligned in recommended products

### DIFF
--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -1,6 +1,9 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'section-related-products.css' | asset_url | stylesheet_tag }}
+{{ 'quick-add.css' | asset_url | stylesheet_tag }}
+
+<script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- include quick-add CSS and script in related products section so quick-add icon matches collection grid

## Testing
- `theme check` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1367e60788325991ee9695ab6c53a