### PR TITLE
Fix quick add icon alignment in product recommendations

### DIFF
--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -1,6 +1,7 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'section-related-products.css' | asset_url | stylesheet_tag }}
+{{ 'quick-add.css' | asset_url | stylesheet_tag }}
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- load quick add stylesheet in Related Products section so the '+' quick add icon matches collection grid positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1367e60788325991ee9695ab6c53a