### PR TITLE
Align quick add button in related products

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1150,6 +1150,27 @@ class ProductRecommendations extends HTMLElement {
         const recommendations = html.querySelector('product-recommendations');
 
         if (recommendations?.innerHTML.trim().length) {
+          const links = recommendations.querySelectorAll('link[rel="stylesheet"]');
+          links.forEach((link) => {
+            const href = link.getAttribute('href');
+            if (href && !document.querySelector(`link[href="${href}"]`)) {
+              document.head.appendChild(link.cloneNode(true));
+            }
+            link.remove();
+          });
+
+          const scripts = recommendations.querySelectorAll('script');
+          scripts.forEach((script) => {
+            const src = script.getAttribute('src');
+            if (src && !document.querySelector(`script[src="${src}"]`)) {
+              const newScript = document.createElement('script');
+              newScript.src = src;
+              if (script.getAttribute('defer') !== null) newScript.defer = true;
+              document.body.appendChild(newScript);
+            }
+            script.remove();
+          });
+
           this.innerHTML = recommendations.innerHTML;
         }
 

--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -1,6 +1,9 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'section-related-products.css' | asset_url | stylesheet_tag }}
+{{ 'quick-add.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- load quick add assets in Related Products section so add-to-cart button aligns with swatches
- ensure dynamically loaded recommendations inject required styles and scripts

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c140684e9c8325b644add6002e46b6