### PR TITLE
Align quick add button in related products

### DIFF
--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -1,6 +1,9 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'section-related-products.css' | asset_url | stylesheet_tag }}
+{{ 'quick-add.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}
@@ -32,6 +35,7 @@
         {{ section.settings.heading }}
       </h2>
       <ul
+        id="product-grid"
         class="grid product-grid grid--{{ section.settings.columns_desktop }}-col-desktop grid--{{ section.settings.columns_mobile }}-col-tablet-down"
         role="list"
       >


### PR DESCRIPTION
## Summary
- load quick add assets in Related Products section to keep add-to-cart button aligned with swatches
- scope swatch styles by giving related products grid the product-grid id

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c140684e9c8325b644add6002e46b6