### PR TITLE
Align quick add button in related products

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1150,7 +1150,30 @@ class ProductRecommendations extends HTMLElement {
         const recommendations = html.querySelector('product-recommendations');
 
         if (recommendations?.innerHTML.trim().length) {
+          const links = html.querySelectorAll('link[rel="stylesheet"]');
+          links.forEach((link) => {
+            const href = link.getAttribute('href');
+            if (href && !document.querySelector(`link[href="${href}"]`)) {
+              document.head.appendChild(link.cloneNode(true));
+            }
+            link.remove();
+          });
+
+          const scripts = html.querySelectorAll('script');
+          const newScripts = [];
+          scripts.forEach((script) => {
+            const src = script.getAttribute('src');
+            if (src && !document.querySelector(`script[src="${src}"]`)) {
+              const newScript = document.createElement('script');
+              newScript.src = src;
+              if (script.getAttribute('defer') !== null) newScript.defer = true;
+              newScripts.push(newScript);
+            }
+            script.remove();
+          });
+
           this.innerHTML = recommendations.innerHTML;
+          newScripts.forEach((script) => document.body.appendChild(script));
         }
 
         if (!this.querySelector('slideshow-component') && this.classList.contains('complementary-products')) {

--- a/assets/swatches-cheyenne.js
+++ b/assets/swatches-cheyenne.js
@@ -1,14 +1,20 @@
-document.addEventListener('DOMContentLoaded', function() {
+function initSwatchesCheyenne() {
   const swatches = document.querySelectorAll('.swatch');
 
-  swatches.forEach(swatch => {
-    swatch.addEventListener('click', function() {
+  swatches.forEach((swatch) => {
+    swatch.addEventListener('click', function () {
       const selectedColor = this.getAttribute('data-color');
-      
-      document.querySelectorAll('.swiper-slide').forEach(slide => {
+
+      document.querySelectorAll('.swiper-slide').forEach((slide) => {
         const slideColor = slide.getAttribute('data-color');
-        slide.style.display = (slideColor === selectedColor) ? 'block' : 'none';
+        slide.style.display = slideColor === selectedColor ? 'block' : 'none';
       });
     });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSwatchesCheyenne);
+} else {
+  initSwatchesCheyenne();
+}

--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -1,6 +1,11 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'section-related-products.css' | asset_url | stylesheet_tag }}
+{{ 'quick-add.css' | asset_url | stylesheet_tag }}
+{{ 'swatches-cheyenne.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'swatches-cheyenne.js' | asset_url }}" defer="defer"></script>
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- load swatch script alongside quick-add assets in Related Products so swatches initialize in recommendations
- inject recommendation scripts after rendering and run swatch JS on already-loaded pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c140684e9c8325b644add6002e46b6