### PR TITLE
Align quick add button in related products

### DIFF
--- a/assets/global.js
+++ b/assets/global.js
@@ -1150,7 +1150,36 @@ class ProductRecommendations extends HTMLElement {
         const recommendations = html.querySelector('product-recommendations');
 
         if (recommendations?.innerHTML.trim().length) {
+          const links = html.querySelectorAll('link[rel="stylesheet"]');
+          links.forEach((link) => {
+            const href = link.getAttribute('href');
+            if (href && !document.querySelector(`link[href="${href}"]`)) {
+              document.head.appendChild(link.cloneNode(true));
+            }
+            link.remove();
+          });
+
+          const scripts = html.querySelectorAll('script');
+          const newScripts = [];
+          scripts.forEach((script) => {
+            const src = script.getAttribute('src');
+            if (src) {
+              if (!document.querySelector(`script[src="${src}"]`)) {
+                const newScript = document.createElement('script');
+                newScript.src = src;
+                if (script.getAttribute('defer') !== null) newScript.defer = true;
+                newScripts.push(newScript);
+              }
+            } else if (script.textContent) {
+              const inlineScript = document.createElement('script');
+              inlineScript.textContent = script.textContent;
+              newScripts.push(inlineScript);
+            }
+            script.remove();
+          });
+
           this.innerHTML = recommendations.innerHTML;
+          newScripts.forEach((script) => document.body.appendChild(script));
         }
 
         if (!this.querySelector('slideshow-component') && this.classList.contains('complementary-products')) {

--- a/assets/swatches-cheyenne.css
+++ b/assets/swatches-cheyenne.css
@@ -84,37 +84,37 @@
 }
 
 #product-grid > li > div > div > div.card__content > div > div > div > div.product-card__swatch-indicator > span {
-  width:23px!important;
-  height: 23px!important;
-  margin-right: 5px!important;
-  border-radius: 20px;  
+  width: 23px !important;
+  height: 23px !important;
+  margin-right: 5px !important;
+  border-radius: 20px;
 }
 
 @media screen and (min-width: 750px) and (max-width: 850px) {
   #product-grid > li > div > div > div.card__content > div > div > div > div.product-card__swatch-indicator > span {
-    width:13px!important;
-    height: 13px!important;
-    margin-right: 5px!important;
+    width: 13px !important;
+    height: 13px !important;
+    margin-right: 5px !important;
     border-radius: 20px;
+  }
 }
 
 @media screen and (min-width: 851px) and (max-width: 1000px) {
   #product-grid > li > div > div > div.card__content > div > div > div > div.product-card__swatch-indicator > span {
-    width:19px!important;
-    height: 19px!important;
-    margin-right: 5px!important;
+    width: 19px !important;
+    height: 19px !important;
+    margin-right: 5px !important;
     border-radius: 20px;
+  }
 }
 
 #FacetsWrapperMobile > div.mobile-facet.mobile-facet-filter\.v\.t\.shopify\.color-pattern > ul > li > div > label.swatch-input__label > span {
-  width: 25px!important;
-  height: 25px!important;
+  width: 25px !important;
+  height: 25px !important;
 }
-
-#FacetsWrapperMobile > div.mobile-facet.mobile-facet-filter\.v\.t\.shopify\.color-pattern > ul > li
 
 #product-grid > li > div > div > div.card__content > div > div > div > div.product-card__swatch-indicator > span.swatch.active {
   border: 2px solid white;
   box-shadow: 0 0 0 1px #000;
-  
 }
+

--- a/assets/swatches-cheyenne.js
+++ b/assets/swatches-cheyenne.js
@@ -1,14 +1,20 @@
-document.addEventListener('DOMContentLoaded', function() {
+function initSwatchesCheyenne() {
   const swatches = document.querySelectorAll('.swatch');
 
-  swatches.forEach(swatch => {
-    swatch.addEventListener('click', function() {
+  swatches.forEach((swatch) => {
+    swatch.addEventListener('click', function () {
       const selectedColor = this.getAttribute('data-color');
-      
-      document.querySelectorAll('.swiper-slide').forEach(slide => {
+
+      document.querySelectorAll('.swiper-slide').forEach((slide) => {
         const slideColor = slide.getAttribute('data-color');
-        slide.style.display = (slideColor === selectedColor) ? 'block' : 'none';
+        slide.style.display = slideColor === selectedColor ? 'block' : 'none';
       });
     });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSwatchesCheyenne);
+} else {
+  initSwatchesCheyenne();
+}

--- a/sections/related-products.liquid
+++ b/sections/related-products.liquid
@@ -1,6 +1,11 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'section-related-products.css' | asset_url | stylesheet_tag }}
+{{ 'quick-add.css' | asset_url | stylesheet_tag }}
+{{ 'swatches-cheyenne.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'quick-add.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'swatches-cheyenne.js' | asset_url }}" defer="defer"></script>
 
 {% if section.settings.image_shape == 'blob' %}
   {{ 'mask-blobs.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
## Summary
- execute inline product-card scripts when recommendations load so quick-add and swatches initialize
- fix malformed swatch stylesheet to restore swatch and quick-add alignment across grids

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c140684e9c8325b644add6002e46b6