### PR TITLE
Ensure collection grid defaults to two-column layout

### DIFF
--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -488,6 +488,14 @@
       grid.classList.add('three-col');
       setActive(btnThreeCol);
     });
+
+    // Ensure the grid reflects the currently active layout button on load
+    const initialActiveButton = [btnOneCol, btnTwoCol, btnThreeCol].find((btn) =>
+      btn.classList.contains('active')
+    );
+    if (initialActiveButton) {
+      initialActiveButton.click();
+    }
   };
 
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- ensure active layout button determines initial grid view so collection pages default to two-column

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c17069df188325bab32a8adf5294c7