### PR TITLE
Ensure collection grid defaults to two-column layout

### DIFF
--- a/sections/main-collection-product-grid.liquid
+++ b/sections/main-collection-product-grid.liquid
@@ -393,7 +393,7 @@
               id="product-grid"
               data-id="{{ section.id }}"
               class="
-                grid product-grid
+                grid product-grid two-col
                 grid--{{ section.settings.columns_mobile }}-col-tablet-down
                 grid--{{ section.settings.columns_desktop }}-col-desktop
                 {% if section.settings.quick_add == 'bulk' %} collection-quick-add-bulk{% endif %}
@@ -488,6 +488,15 @@
       grid.classList.add('three-col');
       setActive(btnThreeCol);
     });
+
+    // Apply the layout corresponding to the active button without triggering a click
+    if (btnOneCol.classList.contains('active')) {
+      grid.classList.add('one-col');
+    } else if (btnTwoCol.classList.contains('active')) {
+      grid.classList.add('two-col');
+    } else if (btnThreeCol.classList.contains('active')) {
+      grid.classList.add('three-col');
+    }
   };
 
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- preload two-column layout class on product grid to eliminate single-column flash
- apply active layout class without triggering click for immediate two-column view

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c17069df188325bab32a8adf5294c7