### PR TITLE
Use color swatches for mobile variant picker

### DIFF
--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -47,6 +47,10 @@
     {{ option.name }}-{{ option.position }}
   {%- endcapture -%}
 
+  {%- capture swatch_input_name -%}
+    options[{{ option.name | escape }}]
+  {%- endcapture -%}
+
   {%- capture input_dataset -%}
     data-product-url="{{ value.product_url }}"
     data-option-value-id="{{ value.id }}"
@@ -66,7 +70,7 @@
     {%
       render 'swatch-input',
       id: input_id,
-      name: input_name,
+      name: swatch_input_name,
       value: value | escape,
       swatch: value.swatch,
       product_form_id: product_form_id,

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -36,10 +36,10 @@
       {%- endif -%}
       
       {%- comment %}
-        For Color options, force swatch dropdown so the swatch is shown.
+        For Color options on mobile, use swatches instead of a dropdown.
       {%- endcomment -%}
       {%- if option.name contains "Color" or option.name contains "Cor" -%}
-        {% assign picker_type = "swatch_dropdown" %}
+        {% assign picker_type = "swatch" %}
       {%- endif -%}
       
       {%- if picker_type == 'swatch' -%}


### PR DESCRIPTION
## Summary
- display color options as swatches instead of dropdown on mobile product pages
- wire swatch inputs to product form so selections add correct variant

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18177bdbc83259d5d960af6e8a1e9