### PR TITLE
Use color swatches for mobile variant picker

### DIFF
--- a/assets/product-info.js
+++ b/assets/product-info.js
@@ -61,7 +61,15 @@ if (!customElements.get('product-info')) {
       }
 
       handleOptionValueChange({ data: { event, target, selectedOptionValues } }) {
-        if (!this.contains(event.target)) return;
+        if (!this.contains(event.target)) {
+          const formId = event.target.getAttribute('form');
+          if (
+            formId !== `product-form-${this.dataset.section}` &&
+            formId !== `product-form-installment-${this.dataset.section}`
+          ) {
+            return;
+          }
+        }
 
         this.resetProductFormState();
 
@@ -212,13 +220,15 @@ if (!customElements.get('product-info')) {
       }
 
       updateVariantInputs(variantId) {
-        this.querySelectorAll(
-          `#product-form-${this.dataset.section}, #product-form-installment-${this.dataset.section}`
-        ).forEach((productForm) => {
-          const input = productForm.querySelector('input[name="id"]');
-          input.value = variantId ?? '';
-          input.dispatchEvent(new Event('change', { bubbles: true }));
-        });
+        document
+          .querySelectorAll(
+            `#product-form-${this.dataset.section}, #product-form-installment-${this.dataset.section}`
+          )
+          .forEach((productForm) => {
+            const input = productForm.querySelector('input[name="id"]');
+            input.value = variantId ?? '';
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+          });
       }
 
       updateURL(url, variantId) {

--- a/snippets/product-variant-options.liquid
+++ b/snippets/product-variant-options.liquid
@@ -16,8 +16,14 @@
     picker_type: picker_type
   %}
 {% endcomment %}
+{%- comment %}
+  product_form_id is passed in from the parent snippet. If it isn't provided,
+  fall back to the default product form id based on the section.
+{%- endcomment -%}
 {%- liquid
-  assign product_form_id = 'product-form-' | append: section.id
+  if product_form_id == blank
+    assign product_form_id = 'product-form-' | append: section.id
+  endif
 -%}
 
 {%- for value in option.values -%}
@@ -47,6 +53,8 @@
     {{ option.name }}-{{ option.position }}
   {%- endcapture -%}
 
+  {%- capture option_input_name -%}options[{{ option.name | escape }}]{%- endcapture -%}
+
   {%- capture input_dataset -%}
     data-product-url="{{ value.product_url }}"
     data-option-value-id="{{ value.id }}"
@@ -66,7 +74,7 @@
     {%
       render 'swatch-input',
       id: input_id,
-      name: input_name,
+      name: option_input_name,
       value: value | escape,
       swatch: value.swatch,
       product_form_id: product_form_id,

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -36,10 +36,10 @@
       {%- endif -%}
       
       {%- comment %}
-        For Color options, force swatch dropdown so the swatch is shown.
+        For Color options on mobile, use swatches instead of a dropdown.
       {%- endcomment -%}
       {%- if option.name contains "Color" or option.name contains "Cor" -%}
-        {% assign picker_type = "swatch_dropdown" %}
+        {% assign picker_type = "swatch" %}
       {%- endif -%}
       
       {%- if picker_type == 'swatch' -%}
@@ -54,7 +54,8 @@
             product: product,
             option: option,
             block: block,
-            picker_type: picker_type
+            picker_type: picker_type,
+            product_form_id: product_form_id
           %}
         </fieldset>
       {%- elsif picker_type == 'button' -%}
@@ -64,7 +65,8 @@
             product: product,
             option: option,
             block: block,
-            picker_type: picker_type
+            picker_type: picker_type,
+            product_form_id: product_form_id
           %}
         </fieldset>
       {%- else -%}
@@ -97,7 +99,8 @@
                 product: product,
                 option: option,
                 block: block,
-                picker_type: picker_type
+                picker_type: picker_type,
+                product_form_id: product_form_id
               %}
             </select>
             <span class="svg-wrapper">


### PR DESCRIPTION
## Summary
- display color options as swatches instead of dropdown on mobile product pages
- ensure swatch selections correctly update the associated product form
- update variant handling to support pickers outside the `product-info` container

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18177bdbc83259d5d960af6e8a1e9