### PR TITLE
Handle wishlist fetch failures gracefully

### DIFF
--- a/templates/page.wishlist.liquid
+++ b/templates/page.wishlist.liquid
@@ -94,8 +94,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   grid.innerHTML = 'A carregar favoritos...';
 
   // Try fetching, even if not logged in
-  const res = await fetch('/apps/wishlist?action=get', { credentials: 'include' });
-  const data = await res.json();
+  let data = { products: [] };
+  try {
+    const res = await fetch('/apps/wishlist?action=get', { credentials: 'include' });
+    if (!res.ok) throw new Error('Wishlist request failed');
+    data = await res.json();
+  } catch (err) {
+    console.error('Failed to load wishlist', err);
+    grid.innerHTML = '<p>No items in wishlist.</p>';
+    return;
+  }
 
   if (!data.products || data.products.length === 0) {
     grid.innerHTML = '<p>No items in wishlist.</p>';


### PR DESCRIPTION
## Summary
- add error handling to wishlist page to cope with failed requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c29d47f1208325a985ae37febacce7