### PR TITLE
feat: add mobile variant picker with size drawer

### DIFF
--- a/sections/sticky-product-bar.liquid
+++ b/sections/sticky-product-bar.liquid
@@ -253,11 +253,114 @@
   margin-bottom: 6px;
 
 }
+
+/* Hide default dropdowns in sticky bar; size will be selected via drawer */
+#sticky-product-bar .product-form__input--dropdown {
+  display: none;
+}
+
+/* Size drawer styles */
+#size-drawer {
+  position: fixed;
+  inset: 0;
+  display: none;
+  z-index: 2001;
+}
+#size-drawer.open {
+  display: block;
+}
+#size-drawer .size-drawer-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+}
+#size-drawer .size-drawer-panel {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border-radius: 10px 10px 0 0;
+  padding: 1rem;
+  max-height: 80%;
+  overflow-y: auto;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+}
+#size-drawer.open .size-drawer-panel {
+  transform: translateY(0);
+}
+#size-drawer .size-option-button {
+  display: block;
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 0.5rem;
+  background: #fff;
+  border: 1px solid #ccc;
+}
+
+.size-select-button {
+  margin-top: 0.5rem;
+  padding: 0.6rem 1rem;
+  border: 1px solid #000;
+  background: #fff;
+}
 </style>
 
 <!-- Provide the product data in JSON -->
 <script>
   var productData = {{ product | json }};
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const bar = document.getElementById('sticky-product-bar');
+  if (!bar) return;
+  const sizeSelect = bar.querySelector('select[name^="options"][name*="Size"]');
+  const openBtn = bar.querySelector('#open-size-drawer');
+  const drawer = document.getElementById('size-drawer');
+  if (!sizeSelect || !openBtn || !drawer) return;
+
+  const overlay = drawer.querySelector('.size-drawer-overlay');
+  const closeBtn = drawer.querySelector('.size-drawer-close');
+  const optionsWrap = drawer.querySelector('.size-drawer-options');
+
+  const populateOptions = () => {
+    optionsWrap.innerHTML = '';
+    Array.from(sizeSelect.options).forEach((opt) => {
+      if (opt.value === '') return;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'size-option-button';
+      btn.textContent = opt.value;
+      btn.addEventListener('click', () => {
+        sizeSelect.value = opt.value;
+        sizeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        openBtn.textContent = opt.value;
+        drawer.classList.remove('open');
+      });
+      optionsWrap.appendChild(btn);
+    });
+  };
+
+  populateOptions();
+  openBtn.textContent = sizeSelect.value || 'Select size';
+
+  const variantEl = bar.querySelector('variant-selects');
+  if (variantEl) {
+    variantEl.addEventListener('change', () => {
+      populateOptions();
+      openBtn.textContent = sizeSelect.value || 'Select size';
+    });
+  }
+
+  const open = () => drawer.classList.add('open');
+  const close = () => drawer.classList.remove('open');
+
+  openBtn.addEventListener('click', open);
+  overlay.addEventListener('click', close);
+  closeBtn.addEventListener('click', close);
+});
 </script>
 
 <!-- Sticky Product Bar Container -->
@@ -276,6 +379,7 @@
           {% unless product.has_only_default_variant %}
           <div class="product-variants">
             {% render 'product-variant-picker', product: product, block: dummy_block, product_form_id: 'product-form-' | append: section.id %}
+            <button type="button" id="open-size-drawer" class="size-select-button">Select size</button>
           </div>
           {% endunless %}
         </div>
@@ -289,6 +393,13 @@
             show_pickup_availability: false
         %}
       </div>
+    </div>
+  </div>
+  <div id="size-drawer">
+    <div class="size-drawer-overlay"></div>
+    <div class="size-drawer-panel">
+      <button type="button" class="size-drawer-close">&times;</button>
+      <div class="size-drawer-options"></div>
     </div>
   </div>
   <div class="size-chart">

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -36,10 +36,10 @@
       {%- endif -%}
       
       {%- comment %}
-        For Color options, force swatch dropdown so the swatch is shown.
+        For Color options, force swatch rendering.
       {%- endcomment -%}
       {%- if option.name contains "Color" or option.name contains "Cor" -%}
-        {% assign picker_type = "swatch_dropdown" %}
+        {% assign picker_type = "swatch" %}
       {%- endif -%}
       
       {%- if picker_type == 'swatch' -%}


### PR DESCRIPTION
## Summary
- render color variants as swatches instead of dropdown
- add bottom drawer for choosing size in sticky product bar
- hide default size dropdown and wire drawer selection to variant picker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f8293910832587ee26b04349c930