### PR TITLE
Add product size guide drawer

### DIFF
--- a/assets/component-size-guide.css
+++ b/assets/component-size-guide.css
@@ -1,0 +1,215 @@
+.size-guide {
+  margin-top: 1.5rem;
+}
+
+.size-guide__trigger {
+  appearance: none;
+  background: none;
+  border: none;
+  color: rgb(var(--color-foreground));
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0;
+  position: relative;
+  text-decoration: none;
+}
+
+.size-guide__trigger::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.15em;
+  width: 100%;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+}
+
+.size-guide__trigger:hover::after,
+.size-guide__trigger:focus-visible::after {
+  opacity: 1;
+}
+
+.size-guide__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.size-guide__overlay.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.size-guide__drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(420px, 90%);
+  max-width: 90%;
+  background: #fff;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 905;
+  display: flex;
+  flex-direction: column;
+}
+
+.size-guide__drawer.is-open {
+  transform: translateX(0);
+}
+
+.size-guide__header {
+  align-items: center;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  display: flex;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+}
+
+.size-guide__heading {
+  font-size: 1.125rem;
+  letter-spacing: 0.02em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.size-guide__close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.75rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.size-guide__body {
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.size-guide__intro {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin-bottom: 1.5rem;
+}
+
+.size-guide__image {
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.size-guide__image img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.size-guide__unit-toggle {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.size-guide__unit-btn {
+  appearance: none;
+  background: #f4f4f4;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 0.35rem 0.75rem;
+  text-transform: uppercase;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.size-guide__unit-btn.is-active {
+  background: rgb(var(--color-foreground));
+  border-color: rgb(var(--color-foreground));
+  color: rgb(var(--color-background));
+}
+
+.size-guide__tables {
+  width: 100%;
+}
+
+.size-guide__table {
+  display: none;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.size-guide__table.is-active {
+  display: table;
+}
+
+.size-guide__table caption {
+  text-align: left;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.size-guide__table th,
+.size-guide__table td {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0.6rem 0.8rem;
+  text-align: center;
+}
+
+.size-guide__table th:first-child,
+.size-guide__table td:first-child {
+  text-align: left;
+  font-weight: 500;
+}
+
+.size-guide__table thead {
+  background: rgba(0, 0, 0, 0.03);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.size-guide__helper-link {
+  display: inline-block;
+  font-size: 0.85rem;
+  margin-bottom: 1.5rem;
+  text-decoration: underline;
+}
+
+.size-guide__empty-state {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  text-align: left;
+}
+
+@media screen and (max-width: 749px) {
+  .size-guide__drawer {
+    width: 100%;
+    max-width: none;
+  }
+
+  .size-guide__body {
+    padding: 1.25rem 1rem 2rem;
+  }
+}
+
+body.size-guide-open {
+  overflow: hidden;
+}

--- a/assets/component-size-guide.js
+++ b/assets/component-size-guide.js
@@ -1,0 +1,167 @@
+class SizeGuideDrawer {
+  constructor(root) {
+    this.root = root;
+    this.trigger = root.querySelector('[data-size-guide-open]');
+    this.drawer = root.querySelector('[data-size-guide-drawer]');
+    this.overlay = root.querySelector('[data-size-guide-overlay]');
+    this.closeButtons = Array.from(root.querySelectorAll('[data-size-guide-close]'));
+    this.unitButtons = Array.from(root.querySelectorAll('[data-size-guide-unit]'));
+    this.tables = Array.from(root.querySelectorAll('[data-size-guide-table]'));
+    this.activeUnit = this.tables.find((table) => table.classList.contains('is-active'))?.dataset.sizeGuideTable || null;
+    this.previouslyFocused = null;
+    this.isOpen = false;
+
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+
+    if (!this.trigger || !this.drawer) {
+      return;
+    }
+
+    this.trigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      this.open();
+    });
+
+    if (this.overlay) {
+      this.overlay.addEventListener('click', () => this.close());
+    }
+
+    this.closeButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.close();
+      });
+    });
+
+    this.unitButtons.forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        this.showUnit(button.dataset.sizeGuideUnit);
+      });
+    });
+  }
+
+  open() {
+    if (this.isOpen) return;
+
+    this.isOpen = true;
+    this.previouslyFocused = document.activeElement;
+    this.drawer.classList.add('is-open');
+    this.drawer.setAttribute('aria-hidden', 'false');
+    this.trigger.setAttribute('aria-expanded', 'true');
+
+    if (this.overlay) {
+      this.overlay.classList.add('is-open');
+    }
+
+    document.body.classList.add('size-guide-open');
+    document.addEventListener('keydown', this.handleKeyDown);
+
+    this.focusDrawer();
+  }
+
+  close() {
+    if (!this.isOpen) return;
+
+    this.isOpen = false;
+    this.drawer.classList.remove('is-open');
+    this.drawer.setAttribute('aria-hidden', 'true');
+    this.trigger.setAttribute('aria-expanded', 'false');
+
+    if (this.overlay) {
+      this.overlay.classList.remove('is-open');
+    }
+
+    document.body.classList.remove('size-guide-open');
+    document.removeEventListener('keydown', this.handleKeyDown);
+
+    if (this.previouslyFocused && typeof this.previouslyFocused.focus === 'function') {
+      this.previouslyFocused.focus({ preventScroll: true });
+    }
+  }
+
+  focusDrawer() {
+    const focusable = this.getFocusableElements();
+    if (focusable.length > 0) {
+      focusable[0].focus({ preventScroll: true });
+    } else {
+      this.drawer.focus({ preventScroll: true });
+    }
+  }
+
+  getFocusableElements() {
+    if (!this.drawer) return [];
+    const selectors = [
+      'a[href]',
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ];
+    return Array.from(this.drawer.querySelectorAll(selectors.join(',')));
+  }
+
+  handleKeyDown(event) {
+    if (!this.isOpen) return;
+
+    if (event.key === 'Escape' || event.key === 'Esc') {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = this.getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      this.drawer.focus({ preventScroll: true });
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus({ preventScroll: true });
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  }
+
+  showUnit(unit) {
+    if (!unit || this.activeUnit === unit) return;
+
+    this.activeUnit = unit;
+
+    this.unitButtons.forEach((button) => {
+      button.classList.toggle('is-active', button.dataset.sizeGuideUnit === unit);
+    });
+
+    this.tables.forEach((table) => {
+      table.classList.toggle('is-active', table.dataset.sizeGuideTable === unit);
+    });
+  }
+}
+
+function initSizeGuideDrawers() {
+  document.querySelectorAll('[data-size-guide]').forEach((root) => {
+    if (!root.__sizeGuideDrawer) {
+      root.__sizeGuideDrawer = new SizeGuideDrawer(root);
+    }
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSizeGuideDrawers);
+} else {
+  initSizeGuideDrawers();
+}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -660,12 +660,13 @@
                 </product-recommendations>
               {%- when 'icon-with-text' -%}
                 {% render 'icon-with-text', block: block %}
-            {%- endcase -%}
-          {%- endfor -%}
-          <a href="{{ product.url }}" class="link product__view-details animate-arrow">
-            {{ 'products.product.view_full_details' | t }}
-            {{- 'icon-arrow.svg' | inline_asset_content -}}
-          </a>
+          {%- endcase -%}
+        {%- endfor -%}
+        {% render 'size-guide-drawer', product: product %}
+        <a href="{{ product.url }}" class="link product__view-details animate-arrow">
+          {{ 'products.product.view_full_details' | t }}
+          {{- 'icon-arrow.svg' | inline_asset_content -}}
+        </a>
         </section>
       </div>
     </div>

--- a/snippets/size-guide-drawer.liquid
+++ b/snippets/size-guide-drawer.liquid
@@ -1,0 +1,185 @@
+{{ 'component-size-guide.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'component-size-guide.js' | asset_url }}" defer="defer"></script>
+
+{%- liquid
+  assign size_guide_key = ''
+  for tag in product.tags
+    assign normalized_tag = tag | strip | downcase
+    if normalized_tag contains 'size_guide_'
+      assign size_guide_key = normalized_tag | remove: 'size_guide_'
+      assign size_guide_key = size_guide_key | replace: ' ', '-'
+      break
+    endif
+  endfor
+
+  assign size_guide_rows_cm = nil
+  assign size_guide_rows_in = nil
+  assign size_guide_headers = 'Zona,S,M,L,XL' | split: ','
+  assign size_guide_title = 'Dimensões do produto'
+  assign size_guide_intro = 'As medidas podem apresentar pequenas variações devido ao processo de produção. A peça de roupa está medida esticada.'
+  assign size_guide_helper_label = 'Consulta como medir a peça de roupa'
+  assign size_guide_helper_url = '/pages/guia-de-tamanhos'
+
+  case size_guide_key
+    when 'hoodie'
+      assign size_guide_rows_cm = 'Peito|61|63,5|66|68,5;Comprimento à frente|68,5|70|71,5|73;Comprimento da manga|64|65|66|67;Largura das costas|53|55,5|57,5|59,5;Largura do braço|26|27|27,5|28' | split: ';'
+      assign size_guide_rows_in = 'Peito|24|25|26|27;Comprimento à frente|27|27,6|28,1|28,7;Comprimento da manga|25,2|25,6|26|26,4;Largura das costas|20,9|21,9|22,6|23,4;Largura do braço|10,2|10,6|10,8|11' | split: ';'
+    when 'tshirt'
+      assign size_guide_rows_cm = 'Peito|49|51|53|55;Comprimento|68|70|72|74;Comprimento da manga|20|21|22|23' | split: ';'
+      assign size_guide_rows_in = 'Peito|19,3|20,1|20,9|21,7;Comprimento|26,8|27,6|28,3|29,1;Comprimento da manga|7,9|8,3|8,7|9,1' | split: ';'
+    when 'pants'
+      assign size_guide_headers = 'Zona,36,38,40,42' | split: ','
+      assign size_guide_rows_cm = 'Cintura|72|76|80|84;Anca|94|98|102|106;Comprimento da perna|78|79|80|81' | split: ';'
+      assign size_guide_rows_in = 'Cintura|28,3|29,9|31,5|33,1;Anca|37|38,6|40,2|41,7;Comprimento da perna|30,7|31,1|31,5|31,9' | split: ';'
+  endcase
+
+  assign default_unit = ''
+  if size_guide_rows_cm
+    assign default_unit = 'cm'
+  elsif size_guide_rows_in
+    assign default_unit = 'in'
+  endif
+
+  assign featured_media = product.media | where: 'media_type', 'image' | first
+  if featured_media == blank
+    assign featured_media = product.featured_media
+  endif
+  if featured_media
+    assign size_guide_image_alt = featured_media.alt | default: product.title
+  endif
+-%}
+
+<div class="size-guide" data-size-guide>
+  <button
+    type="button"
+    class="size-guide__trigger"
+    data-size-guide-open
+    aria-haspopup="dialog"
+    aria-expanded="false"
+  >
+    Guia de tamanhos
+  </button>
+  <div class="size-guide__overlay" data-size-guide-overlay></div>
+  <aside
+    class="size-guide__drawer"
+    role="dialog"
+    aria-modal="true"
+    aria-hidden="true"
+    tabindex="-1"
+    data-size-guide-drawer
+  >
+    <div class="size-guide__header">
+      <h2 class="size-guide__heading">{{ size_guide_title }}</h2>
+      <button
+        type="button"
+        class="size-guide__close"
+        aria-label="Fechar guia de tamanhos"
+        data-size-guide-close
+      >
+        &times;
+      </button>
+    </div>
+    <div class="size-guide__body">
+      <p class="size-guide__intro">{{ size_guide_intro }}</p>
+      {% if size_guide_helper_url != blank %}
+        <a class="size-guide__helper-link" href="{{ size_guide_helper_url }}">{{ size_guide_helper_label }}</a>
+      {% endif %}
+      {% if featured_media %}
+        <div class="size-guide__image">
+          {{ featured_media | image_url: width: 600 | image_tag: loading: 'lazy', widths: '180,360,540,720', sizes: '(min-width: 750px) 360px, 80vw', alt: size_guide_image_alt }}
+        </div>
+      {% endif %}
+
+      {% if size_guide_rows_cm or size_guide_rows_in %}
+        {% if size_guide_rows_cm and size_guide_rows_in %}
+          <div class="size-guide__unit-toggle" role="group" aria-label="Selecionar unidade de medida">
+            <button
+              type="button"
+              class="size-guide__unit-btn{% if default_unit == 'cm' %} is-active{% endif %}"
+              data-size-guide-unit="cm"
+            >
+              CM
+            </button>
+            <button
+              type="button"
+              class="size-guide__unit-btn{% if default_unit == 'in' %} is-active{% endif %}"
+              data-size-guide-unit="in"
+            >
+              IN
+            </button>
+          </div>
+        {% endif %}
+
+        <div class="size-guide__tables">
+          {% if size_guide_rows_cm %}
+            <table
+              class="size-guide__table{% if default_unit == 'cm' %} is-active{% endif %}"
+              data-size-guide-table="cm"
+            >
+              <caption>Medidas em centímetros</caption>
+              <thead>
+                <tr>
+                  {% for header in size_guide_headers %}
+                    <th scope="col">{{ header }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in size_guide_rows_cm %}
+                  {% assign values = row | split: '|' %}
+                  {% if values.size > 0 %}
+                    <tr>
+                      {% for value in values %}
+                        {% if forloop.first %}
+                          <th scope="row">{{ value }}</th>
+                        {% else %}
+                          <td>{{ value }}</td>
+                        {% endif %}
+                      {% endfor %}
+                    </tr>
+                  {% endif %}
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endif %}
+
+          {% if size_guide_rows_in %}
+            <table
+              class="size-guide__table{% if default_unit == 'in' %} is-active{% endif %}"
+              data-size-guide-table="in"
+            >
+              <caption>Medidas em polegadas</caption>
+              <thead>
+                <tr>
+                  {% for header in size_guide_headers %}
+                    <th scope="col">{{ header }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in size_guide_rows_in %}
+                  {% assign values = row | split: '|' %}
+                  {% if values.size > 0 %}
+                    <tr>
+                      {% for value in values %}
+                        {% if forloop.first %}
+                          <th scope="row">{{ value }}</th>
+                        {% else %}
+                          <td>{{ value }}</td>
+                        {% endif %}
+                      {% endfor %}
+                    </tr>
+                  {% endif %}
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endif %}
+        </div>
+      {% else %}
+        <p class="size-guide__empty-state">
+          Adiciona uma tag no formato <code>size_guide_tipo</code> a este produto para mostrar uma tabela de medidas. Exemplos disponíveis: <code>size_guide_hoodie</code>, <code>size_guide_tshirt</code>, <code>size_guide_pants</code>.
+        </p>
+      {% endif %}
+    </div>
+  </aside>
+</div>


### PR DESCRIPTION
## Summary
- add a reusable size guide drawer snippet that reads product tags to build the appropriate measurement tables and surface the first product image
- wire the size guide link into the product template and include dedicated styling and scripting for the drawer experience
- provide centimetre and inch tables for hoodies, t-shirts, and pants with a helpful fallback message when no size guide tag is present

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9248a1ec48325843d4567b5371099