### PR TITLE
Add product size guide drawer

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -4234,6 +4234,186 @@ font-style: normal;
     color: orange;
 }
 
+.product-size-guide {
+  margin-top: 1.6rem;
+}
+
+.product-size-guide__trigger {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  color: rgb(var(--color-foreground));
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+.product-size-guide__trigger:hover {
+  opacity: 0.7;
+}
+
+.product-size-guide__drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.product-size-guide.is-open .product-size-guide__drawer {
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.product-size-guide__backdrop {
+  flex: 1 1 auto;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.product-size-guide.is-open .product-size-guide__backdrop {
+  opacity: 1;
+}
+
+.product-size-guide__panel {
+  position: relative;
+  width: min(480px, 100%);
+  height: 100%;
+  background: rgb(var(--color-background));
+  color: rgb(var(--color-foreground));
+  padding: 3.2rem 3.2rem 4rem;
+  overflow-y: auto;
+  box-shadow: -16px 0 32px rgba(0, 0, 0, 0.12);
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+}
+
+.product-size-guide.is-open .product-size-guide__panel {
+  transform: translateX(0);
+}
+
+@media screen and (max-width: 749px) {
+  .product-size-guide__drawer {
+    justify-content: center;
+    align-items: flex-end;
+  }
+
+  .product-size-guide__panel {
+    width: 100%;
+    height: 90vh;
+    border-radius: 20px 20px 0 0;
+    transform: translateY(100%);
+  }
+
+  .product-size-guide.is-open .product-size-guide__panel {
+    transform: translateY(0);
+  }
+}
+
+.product-size-guide__close {
+  position: absolute;
+  top: 1.6rem;
+  right: 1.6rem;
+  background: none;
+  border: none;
+  font-size: 2.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+}
+
+.product-size-guide__title {
+  font-size: 1.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 1.6rem;
+}
+
+.product-size-guide__description {
+  margin-bottom: 2rem;
+  font-size: 1.4rem;
+  line-height: 1.6;
+}
+
+.product-size-guide__media {
+  margin-bottom: 2.4rem;
+}
+
+.product-size-guide__image {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 8px;
+}
+
+.product-size-guide__helper {
+  margin-bottom: 2rem;
+  font-size: 1.3rem;
+}
+
+.product-size-guide__helper a {
+  text-decoration: underline;
+}
+
+.product-size-guide__unit-toggle {
+  display: inline-flex;
+  border: 1px solid rgba(var(--color-foreground), 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-bottom: 2.4rem;
+}
+
+.product-size-guide__unit {
+  background: none;
+  border: none;
+  padding: 0.6rem 1.6rem;
+  font-size: 1.3rem;
+  cursor: pointer;
+  color: inherit;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.product-size-guide__unit.is-active {
+  background: rgb(var(--color-foreground));
+  color: rgb(var(--color-background));
+}
+
+.product-size-guide__table-wrapper {
+  overflow-x: auto;
+}
+
+.product-size-guide__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1.3rem;
+}
+
+.product-size-guide__table th,
+.product-size-guide__table td {
+  padding: 0.9rem 0.8rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(var(--color-foreground), 0.12);
+}
+
+.product-size-guide__table th {
+  font-weight: 600;
+}
+
+.product-size-guide__table tbody th {
+  font-weight: 500;
+}
+
+body.size-guide-open {
+  overflow: hidden;
+}
+
 @media screen and (max-width: 749px) {
 #product-grid > div.title-wrapper.center > h2 {
   margin: 4rem 5rem!important;

--- a/sections/cheyenne-product.liquid
+++ b/sections/cheyenne-product.liquid
@@ -617,6 +617,7 @@
 
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
+                {% render 'product-size-guide', product: product, section_id: section.id %}
               {%- when 'buy_buttons' -%}
                 {%- render 'buy-buttons',
                   block: block,

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -463,6 +463,7 @@
 
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
+                {% render 'product-size-guide', product: product, section_id: section.id %}
               {%- when 'buy_buttons' -%}
                 {%- render 'buy-buttons',
                   block: block,

--- a/snippets/product-size-guide.liquid
+++ b/snippets/product-size-guide.liquid
@@ -1,0 +1,324 @@
+{% comment %}
+  Size guide drawer for product pages.
+  - Define measurement tables below and match them with product tags.
+  - The first matching tag determines which table is shown. If none match, the
+    entry marked with "default": true is used.
+  - Add additional table definitions inside `size_guide_json` as needed.
+{% endcomment %}
+
+{% capture size_guide_json %}
+[
+  {
+    "tag": "guide-hoodie",
+    "trigger_text": "Guia de tamanhos",
+    "title": "Dimensões do produto",
+    "description": "As medidas podem apresentar pequenas variações devido ao processo de produção. A peça de roupa está medida esticada.",
+    "helper_html": "Consulta <a href=\"/pages/guia-de-tamanhos\">como medir a peça de roupa</a>.",
+    "row_label": "Zona",
+    "unit_labels": {"cm": "CM", "inch": "IN"},
+    "sizes": ["S", "M", "L", "XL"],
+    "rows": [
+      {"label": "Peito", "values": [61, 64.5, 67, 71]},
+      {"label": "Comprimento à frente", "values": [63.5, 70, 71.5, 75]},
+      {"label": "Comprimento da manga", "values": [63, 63.5, 65, 66.5]},
+      {"label": "Largura das costas", "values": [53, 55.5, 58, 60]},
+      {"label": "Largura do braço", "values": [26, 27, 27.5, 28]}
+    ]
+  },
+  {
+    "tag": "guide-default",
+    "default": true,
+    "trigger_text": "Guia de tamanhos",
+    "title": "Dimensões do produto",
+    "description": "As medidas podem apresentar pequenas variações devido ao processo de produção. A peça de roupa está medida esticada.",
+    "helper_html": "Consulta <a href=\"/pages/guia-de-tamanhos\">como medir a peça de roupa</a>.",
+    "row_label": "Zona",
+    "unit_labels": {"cm": "CM", "inch": "IN"},
+    "sizes": ["S", "M", "L", "XL"],
+    "rows": [
+      {"label": "Peito", "values": [61, 64.5, 67, 71]},
+      {"label": "Comprimento à frente", "values": [63.5, 70, 71.5, 75]},
+      {"label": "Comprimento da manga", "values": [63, 63.5, 65, 66.5]},
+      {"label": "Largura das costas", "values": [53, 55.5, 58, 60]},
+      {"label": "Largura do braço", "values": [26, 27, 27.5, 28]}
+    ]
+  }
+]
+{% endcapture %}
+
+{% assign size_guide_tables = size_guide_json | strip | parse_json %}
+{% assign size_guide_config = nil %}
+
+{% if product and size_guide_tables %}
+  {% for table in size_guide_tables %}
+    {% if product.tags contains table.tag %}
+      {% assign size_guide_config = table %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+
+  {% if size_guide_config == nil %}
+    {% for table in size_guide_tables %}
+      {% if table.default %}
+        {% assign size_guide_config = table %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+
+{% if size_guide_config %}
+  {% liquid
+    assign guide_identifier = section_id | default: product.id
+    assign guide_identifier = guide_identifier | append: ''
+    assign root_id = 'size-guide-' | append: guide_identifier
+    assign drawer_id = root_id | append: '-drawer'
+    assign heading_id = root_id | append: '-title'
+    assign open_button_id = root_id | append: '-open'
+
+    assign featured_media = product.selected_or_first_available_variant.featured_media | default: product.featured_media
+    if featured_media == blank and product.media.size > 0
+      assign featured_media = product.media | first
+    endif
+    assign size_guide_image_alt = featured_media.alt | default: product.title
+  %}
+
+  <div class="product-size-guide" data-size-guide="{{ root_id }}">
+    <button
+      type="button"
+      class="product-size-guide__trigger size-guide-link"
+      id="{{ open_button_id }}"
+      aria-controls="{{ drawer_id }}"
+      aria-expanded="false"
+      data-size-guide-open
+    >
+      {{ size_guide_config.trigger_text | default: 'Guia de tamanhos' }}
+    </button>
+
+    <div
+      class="product-size-guide__drawer"
+      id="{{ drawer_id }}"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="{{ heading_id }}"
+      aria-hidden="true"
+      data-size-guide-drawer
+    >
+      <div class="product-size-guide__backdrop" data-size-guide-close></div>
+      <div class="product-size-guide__panel" data-size-guide-panel>
+        <button
+          type="button"
+          class="product-size-guide__close"
+          data-size-guide-close
+          aria-label="Fechar guia de tamanhos"
+        >&times;</button>
+
+        <div class="product-size-guide__content">
+          <h2 class="product-size-guide__title" id="{{ heading_id }}">
+            {{ size_guide_config.title | default: 'Guia de tamanhos' }}
+          </h2>
+
+          {% if size_guide_config.description != blank %}
+            <p class="product-size-guide__description">{{ size_guide_config.description }}</p>
+          {% endif %}
+
+          {% if featured_media %}
+            <div class="product-size-guide__media">
+              {{ featured_media | image_url: width: 900 | image_tag: class: 'product-size-guide__image', loading: 'lazy', alt: size_guide_image_alt | escape }}
+            </div>
+          {% endif %}
+
+          {% if size_guide_config.helper_html != blank %}
+            <p class="product-size-guide__helper">{{ size_guide_config.helper_html }}</p>
+          {% endif %}
+
+          <div class="product-size-guide__unit-toggle" role="group" aria-label="Unidades">
+            <button
+              type="button"
+              class="product-size-guide__unit is-active"
+              data-size-guide-unit="cm"
+              aria-pressed="true"
+            >
+              {{ size_guide_config.unit_labels.cm | default: 'CM' }}
+            </button>
+            <button
+              type="button"
+              class="product-size-guide__unit"
+              data-size-guide-unit="inch"
+              aria-pressed="false"
+            >
+              {{ size_guide_config.unit_labels.inch | default: 'IN' }}
+            </button>
+          </div>
+
+          <div class="product-size-guide__table-wrapper">
+            <table class="product-size-guide__table" data-size-guide-table>
+              <thead>
+                <tr>
+                  <th scope="col">{{ size_guide_config.row_label | default: 'Zona' }}</th>
+                  {% for size in size_guide_config.sizes %}
+                    <th scope="col">{{ size }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in size_guide_config.rows %}
+                  <tr>
+                    <th scope="row">{{ row.label }}</th>
+                    {% for value in row.values %}
+                      <td data-size-guide-value="{{ value }}">{{ value }}</td>
+                    {% endfor %}
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var root = document.querySelector('[data-size-guide="{{ root_id }}"]');
+      if (!root || root.dataset.sizeGuideReady === 'true') {
+        return;
+      }
+      root.dataset.sizeGuideReady = 'true';
+
+      var drawer = root.querySelector('[data-size-guide-drawer]');
+      var panel = root.querySelector('[data-size-guide-panel]');
+      var openButton = root.querySelector('[data-size-guide-open]');
+      var closeButtons = root.querySelectorAll('[data-size-guide-close]');
+      var unitButtons = root.querySelectorAll('[data-size-guide-unit]');
+      var table = root.querySelector('[data-size-guide-table]');
+      var activeUnit = 'cm';
+      var focusableSelectors = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+      var focusableElements = [];
+      var firstFocusable = null;
+      var lastFocusable = null;
+
+      function setFocusableElements() {
+        if (!panel) { return; }
+        focusableElements = Array.prototype.slice.call(panel.querySelectorAll(focusableSelectors));
+        firstFocusable = focusableElements.length ? focusableElements[0] : null;
+        lastFocusable = focusableElements.length ? focusableElements[focusableElements.length - 1] : null;
+      }
+
+      function openDrawer() {
+        if (!drawer) { return; }
+        root.classList.add('is-open');
+        drawer.setAttribute('aria-hidden', 'false');
+        if (openButton) {
+          openButton.setAttribute('aria-expanded', 'true');
+        }
+        document.body.classList.add('size-guide-open');
+        setFocusableElements();
+        if (firstFocusable) {
+          firstFocusable.focus();
+        }
+      }
+
+      function closeDrawer() {
+        if (!drawer) { return; }
+        root.classList.remove('is-open');
+        drawer.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('size-guide-open');
+        if (openButton) {
+          openButton.setAttribute('aria-expanded', 'false');
+          openButton.focus();
+        }
+      }
+
+      function handleFocusTrap(event) {
+        if (event.key !== 'Tab' || focusableElements.length === 0) {
+          return;
+        }
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstFocusable || !document.activeElement) {
+            event.preventDefault();
+            lastFocusable.focus();
+          }
+        } else if (document.activeElement === lastFocusable) {
+          event.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+
+      function handleKeydown(event) {
+        if (!root.classList.contains('is-open')) {
+          return;
+        }
+
+        if (event.key === 'Escape' || event.key === 'Esc') {
+          closeDrawer();
+        } else {
+          handleFocusTrap(event);
+        }
+      }
+
+      function formatValue(baseValue, unit) {
+        var numeric = parseFloat(baseValue);
+        if (isNaN(numeric)) {
+          return baseValue;
+        }
+        if (unit === 'inch') {
+          numeric = numeric / 2.54;
+        }
+        return numeric.toFixed(1);
+      }
+
+      function updateTable(unit) {
+        if (!table) { return; }
+        var cells = table.querySelectorAll('[data-size-guide-value]');
+        cells.forEach(function(cell) {
+          var base = cell.getAttribute('data-size-guide-value');
+          cell.textContent = formatValue(base, unit);
+        });
+        activeUnit = unit;
+        unitButtons.forEach(function(button) {
+          var isActive = button.dataset.sizeGuideUnit === unit;
+          button.classList.toggle('is-active', isActive);
+          button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+      }
+
+      if (openButton) {
+        openButton.addEventListener('click', function(event) {
+          event.preventDefault();
+          openDrawer();
+        });
+      }
+
+      closeButtons.forEach(function(button) {
+        button.addEventListener('click', function(event) {
+          event.preventDefault();
+          closeDrawer();
+        });
+      });
+
+      if (drawer) {
+        drawer.addEventListener('click', function(event) {
+          if (event.target === drawer) {
+            closeDrawer();
+          }
+        });
+      }
+
+      unitButtons.forEach(function(button) {
+        button.addEventListener('click', function(event) {
+          event.preventDefault();
+          var requestedUnit = button.dataset.sizeGuideUnit;
+          if (!requestedUnit || requestedUnit === activeUnit) {
+            return;
+          }
+          updateTable(requestedUnit);
+        });
+      });
+
+      document.addEventListener('keydown', handleKeydown);
+      updateTable(activeUnit);
+    })();
+  </script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add a reusable `product-size-guide` snippet that builds a drawer using product tags to choose the correct measurement table
- wire the drawer into the main and cheyenne product sections so every product page shows the new "Guia de tamanhos" link
- add styling and client-side behaviour for the drawer, unit toggle and image display

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68c9248a1ec48325843d4567b5371099