### PR TITLE
Replace legacy size chart with new guide across product sections

### DIFF
--- a/assets/component-size-guide.css
+++ b/assets/component-size-guide.css
@@ -1,0 +1,240 @@
+.product-size-guide {
+  margin-top: 1.6rem;
+}
+
+.product-size-guide__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0;
+  background: none;
+  border: 0;
+  font: inherit;
+  color: rgb(var(--color-foreground));
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.product-size-guide__trigger:hover {
+  opacity: 0.75;
+}
+
+.product-size-guide__trigger:focus-visible {
+  outline: 2px solid rgba(var(--color-foreground), 0.45);
+  outline-offset: 3px;
+}
+
+.product-size-guide__trigger-icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.product-size-guide__trigger-icon svg {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
+body.size-guide-open {
+  overflow: hidden;
+}
+
+.product-size-guide__drawer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  z-index: 80;
+}
+
+.product-size-guide__drawer--open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.product-size-guide__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.product-size-guide__drawer--open .product-size-guide__overlay {
+  opacity: 1;
+}
+
+.product-size-guide__panel {
+  position: relative;
+  width: min(420px, 92vw);
+  max-width: 480px;
+  height: 100vh;
+  background: rgb(var(--color-background));
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  box-shadow: -24px 0 48px rgba(15, 23, 42, 0.18);
+  display: flex;
+  flex-direction: column;
+}
+
+.product-size-guide__drawer--open .product-size-guide__panel {
+  transform: translateX(0);
+}
+
+.product-size-guide__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.2rem;
+  padding: 2.4rem 2.4rem 1.2rem;
+}
+
+.product-size-guide__eyebrow {
+  margin: 0 0 0.4rem;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(var(--color-foreground), 0.6);
+}
+
+.product-size-guide__heading {
+  margin: 0;
+  font-size: 2.2rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.product-size-guide__close {
+  border: 0;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  line-height: 0;
+  color: rgb(var(--color-foreground));
+}
+
+.product-size-guide__close:hover {
+  opacity: 0.75;
+}
+
+.product-size-guide__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 2.4rem 2.4rem;
+}
+
+.product-size-guide__media {
+  margin-bottom: 1.6rem;
+}
+
+.product-size-guide__image {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.product-size-guide__description {
+  margin: 0 0 0.8rem;
+  font-size: 1.3rem;
+  line-height: 1.5;
+  color: rgba(var(--color-foreground), 0.8);
+}
+
+.product-size-guide__help {
+  margin: 0 0 1.6rem;
+}
+
+.product-size-guide__help-link {
+  color: rgb(var(--color-foreground));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.product-size-guide__help-link:hover {
+  opacity: 0.75;
+}
+
+.product-size-guide__unit-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.2rem;
+  margin-bottom: 1.2rem;
+}
+
+.product-size-guide__unit-button {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(var(--color-foreground), 0.65);
+  cursor: pointer;
+}
+
+.product-size-guide__unit-button.is-active {
+  color: rgb(var(--color-foreground));
+  font-weight: 600;
+}
+
+.product-size-guide__unit-button:focus-visible {
+  outline: 2px solid rgba(var(--color-foreground), 0.45);
+  outline-offset: 3px;
+}
+
+.product-size-guide__table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.product-size-guide__table th,
+.product-size-guide__table td {
+  padding: 0.9rem 0.6rem;
+  font-size: 1.3rem;
+  border-bottom: 1px solid rgba(var(--color-foreground), 0.1);
+}
+
+.product-size-guide__table thead th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 1.1rem;
+  text-align: center;
+}
+
+.product-size-guide__table tbody th {
+  text-align: left;
+  font-weight: 600;
+}
+
+.product-size-guide__table tbody td {
+  text-align: center;
+}
+
+.product-size-guide__empty {
+  margin-top: 1.6rem;
+  font-size: 1.3rem;
+  line-height: 1.6;
+}
+
+@media screen and (max-width: 749px) {
+  .product-size-guide__panel {
+    width: 100%;
+    max-width: none;
+  }
+
+  .product-size-guide__header,
+  .product-size-guide__body {
+    padding-left: 1.6rem;
+    padding-right: 1.6rem;
+  }
+}

--- a/assets/size-guide-drawer.js
+++ b/assets/size-guide-drawer.js
@@ -1,0 +1,299 @@
+if (typeof window === 'undefined' || !window.ShopifySizeGuideDrawerLoaded) {
+  if (typeof window !== 'undefined') {
+    window.ShopifySizeGuideDrawerLoaded = true;
+  }
+
+  (function () {
+  const SELECTOR = '[data-size-guide]';
+  const instances = new WeakMap();
+
+  class ProductSizeGuide {
+    constructor(element) {
+      this.element = element;
+      this.drawer = element.querySelector('[data-size-guide-drawer]');
+      this.trigger = element.querySelector('[data-size-guide-trigger]');
+      this.tableWrapper = element.querySelector('[data-size-guide-table]');
+      this.unitButtons = Array.from(element.querySelectorAll('[data-size-guide-unit]'));
+      this.closeElements = Array.from(element.querySelectorAll('[data-size-guide-close]'));
+
+      this.handleTriggerClick = this.open.bind(this);
+      this.handleCloseClick = this.close.bind(this);
+      this.handleKeyDown = this.onKeyDown.bind(this);
+      this.handleUnitClick = this.onUnitClick.bind(this);
+
+      this.previouslyFocusedElement = null;
+      this.focusableElements = [];
+      this.tableData = null;
+      this.currentUnit = null;
+
+      this.registerEvents();
+      this.prepareTable();
+    }
+
+    registerEvents() {
+      if (this.trigger) {
+        this.trigger.addEventListener('click', this.handleTriggerClick);
+      }
+
+      this.closeElements.forEach((el) => {
+        el.addEventListener('click', this.handleCloseClick);
+      });
+
+      this.unitButtons.forEach((button) => {
+        button.addEventListener('click', this.handleUnitClick);
+      });
+    }
+
+    unregisterEvents() {
+      if (this.trigger) {
+        this.trigger.removeEventListener('click', this.handleTriggerClick);
+      }
+
+      this.closeElements.forEach((el) => {
+        el.removeEventListener('click', this.handleCloseClick);
+      });
+
+      this.unitButtons.forEach((button) => {
+        button.removeEventListener('click', this.handleUnitClick);
+      });
+
+      document.removeEventListener('keydown', this.handleKeyDown);
+    }
+
+    prepareTable() {
+      if (!this.tableWrapper) {
+        return;
+      }
+
+      const rawData = this.tableWrapper.dataset.table;
+      if (!rawData) {
+        return;
+      }
+
+      try {
+        this.tableData = JSON.parse(rawData);
+      } catch (error) {
+        console.warn('Size guide: unable to parse table data', error);
+        this.tableData = null;
+        return;
+      }
+
+      this.currentUnit = this.baseUnit;
+      this.setUnit(this.currentUnit, true);
+    }
+
+    get baseUnit() {
+      if (!this.tableWrapper) {
+        return 'cm';
+      }
+      return this.tableWrapper.dataset.baseUnit || 'cm';
+    }
+
+    open(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      if (!this.drawer || this.isOpen()) {
+        return;
+      }
+
+      this.previouslyFocusedElement = document.activeElement;
+      this.drawer.classList.add('product-size-guide__drawer--open');
+      this.drawer.setAttribute('aria-hidden', 'false');
+      if (this.trigger) {
+        this.trigger.setAttribute('aria-expanded', 'true');
+      }
+      document.body.classList.add('size-guide-open');
+      document.addEventListener('keydown', this.handleKeyDown);
+
+      this.focusableElements = this.getFocusableElements();
+      if (this.focusableElements.length) {
+        this.focusableElements[0].focus();
+      }
+    }
+
+    close(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      if (!this.drawer || !this.isOpen()) {
+        return;
+      }
+
+      this.drawer.classList.remove('product-size-guide__drawer--open');
+      this.drawer.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('size-guide-open');
+      document.removeEventListener('keydown', this.handleKeyDown);
+
+      if (this.trigger) {
+        this.trigger.setAttribute('aria-expanded', 'false');
+        this.trigger.focus();
+      } else if (this.previouslyFocusedElement) {
+        this.previouslyFocusedElement.focus();
+      }
+    }
+
+    isOpen() {
+      return this.drawer && this.drawer.classList.contains('product-size-guide__drawer--open');
+    }
+
+    onKeyDown(event) {
+      if (!this.isOpen()) {
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        this.close();
+      } else if (event.key === 'Tab') {
+        this.trapFocus(event);
+      }
+    }
+
+    trapFocus(event) {
+      this.focusableElements = this.getFocusableElements();
+      if (!this.focusableElements.length) {
+        return;
+      }
+
+      const first = this.focusableElements[0];
+      const last = this.focusableElements[this.focusableElements.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          last.focus();
+          event.preventDefault();
+        }
+      } else if (document.activeElement === last) {
+        first.focus();
+        event.preventDefault();
+      }
+    }
+
+    getFocusableElements() {
+      if (!this.drawer) {
+        return [];
+      }
+      return Array.from(
+        this.drawer.querySelectorAll(
+          'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      );
+    }
+
+    onUnitClick(event) {
+      event.preventDefault();
+      const button = event.currentTarget;
+      const unit = button.dataset.unit;
+      if (!unit || unit === this.currentUnit) {
+        return;
+      }
+      this.setUnit(unit, true);
+    }
+
+    setUnit(unit, updateTable) {
+      this.currentUnit = unit;
+      this.unitButtons.forEach((button) => {
+        const isActive = button.dataset.unit === unit;
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+
+      if (updateTable && this.tableData) {
+        this.renderTable(unit);
+      }
+    }
+
+    renderTable(unit) {
+      if (!this.tableWrapper || !this.tableData || !Array.isArray(this.tableData.rows)) {
+        return;
+      }
+
+      const baseUnit = this.baseUnit;
+      const rows = Array.from(this.tableWrapper.querySelectorAll('tbody tr'));
+
+      rows.forEach((row, rowIndex) => {
+        const dataRow = this.tableData.rows[rowIndex];
+        if (!dataRow || !Array.isArray(dataRow.values)) {
+          return;
+        }
+
+        const cells = Array.from(row.querySelectorAll('td'));
+        cells.forEach((cell, cellIndex) => {
+          const baseValue = dataRow.values[cellIndex];
+          if (typeof baseValue !== 'number') {
+            cell.textContent = baseValue;
+            return;
+          }
+
+          let value = baseValue;
+          if (unit !== baseUnit) {
+            if (baseUnit === 'cm' && unit === 'in') {
+              value = baseValue / 2.54;
+            } else if (baseUnit === 'in' && unit === 'cm') {
+              value = baseValue * 2.54;
+            }
+          }
+
+          cell.textContent = this.formatValue(value, unit);
+        });
+      });
+
+      this.tableWrapper.dataset.currentUnit = unit;
+    }
+
+    formatValue(value, unit) {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        return value;
+      }
+
+      const isInteger = Number.isInteger(value);
+      const fractionDigits = unit === 'in' ? 1 : isInteger ? 0 : 1;
+
+      return value.toLocaleString('pt-PT', {
+        minimumFractionDigits: fractionDigits,
+        maximumFractionDigits: fractionDigits
+      });
+    }
+
+    destroy() {
+      this.unregisterEvents();
+      this.focusableElements = [];
+      this.tableData = null;
+    }
+  }
+
+  function init(context) {
+    const scope = context || document;
+    scope.querySelectorAll(SELECTOR).forEach((element) => {
+      if (!instances.has(element)) {
+        instances.set(element, new ProductSizeGuide(element));
+      }
+    });
+  }
+
+  function destroy(context) {
+    const scope = context || document;
+    scope.querySelectorAll(SELECTOR).forEach((element) => {
+      const instance = instances.get(element);
+      if (instance) {
+        instance.destroy();
+        instances.delete(element);
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => init());
+  } else {
+    init();
+  }
+
+  document.addEventListener('shopify:section:load', (event) => {
+    init(event.target);
+  });
+
+  document.addEventListener('shopify:section:unload', (event) => {
+    destroy(event.target);
+  });
+  })();
+}

--- a/sections/cheyenne-product.liquid
+++ b/sections/cheyenne-product.liquid
@@ -22,6 +22,7 @@
   {{ 'component-slider.css' | asset_url | stylesheet_tag }}
   {{ 'component-rating.css' | asset_url | stylesheet_tag }}
   {{ 'component-deferred-media.css' | asset_url | stylesheet_tag }}
+  {{ 'component-size-guide.css' | asset_url | stylesheet_tag }}
 
   {% unless product.has_only_default_variant %}
     {{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
@@ -49,6 +50,7 @@
   <!-- Scripts for Dawn’s normal product experience -->
   <script src="{{ 'product-info.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+  <script src="{{ 'size-guide-drawer.js' | asset_url }}" defer="defer"></script>
   {%- if product.quantity_price_breaks_configured? -%}
     <script src="{{ 'show-more.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'price-per-item.js' | asset_url }}" defer="defer"></script>
@@ -617,6 +619,7 @@
 
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
+                {% render 'product-size-guide', product: product, section_id: section.id | append: '-cheyenne' %}
               {%- when 'buy_buttons' -%}
                 {%- render 'buy-buttons',
                   block: block,

--- a/sections/desktop-product.liquid
+++ b/sections/desktop-product.liquid
@@ -25,6 +25,8 @@
 {{ 'component-swatch-input.css' | asset_url | stylesheet_tag }}
 {{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
 {{ 'component-swatch.css' | asset_url | stylesheet_tag }}
+{{ 'component-size-guide.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'size-guide-drawer.js' | asset_url }}" defer="defer"></script>
 
 <style>
   /* Hide this entire desktop section on mobile, to avoid conflict */
@@ -423,8 +425,8 @@
 
     <!-- Description container (will be filled by JS) -->
     <div class="product-description" id="DesktopDescContainer">{{ product.description }}</div>
-        <div>
-    {% render 'size-chart-desktop' %}
+    <div>
+      {% render 'product-size-guide', product: product, section_id: section.id | append: '-desktop' %}
     </div>
     {% unless product.has_only_default_variant %}
       <!-- Variant Picker -->

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -15,6 +15,7 @@
   {{ 'component-slider.css' | asset_url | stylesheet_tag }}
   {{ 'component-rating.css' | asset_url | stylesheet_tag }}
   {{ 'component-deferred-media.css' | asset_url | stylesheet_tag }}
+  {{ 'component-size-guide.css' | asset_url | stylesheet_tag }}
 
   {% unless product.has_only_default_variant %}
     {{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
@@ -41,6 +42,7 @@
 
   <script src="{{ 'product-info.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+  <script src="{{ 'size-guide-drawer.js' | asset_url }}" defer="defer"></script>
   {%- if product.quantity_price_breaks_configured? -%}
     <script src="{{ 'show-more.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'price-per-item.js' | asset_url }}" defer="defer"></script>
@@ -463,6 +465,7 @@
 
               {%- when 'variant_picker' -%}
                 {% render 'product-variant-picker', product: product, block: block, product_form_id: product_form_id %}
+                {% render 'product-size-guide', product: product, section_id: section.id %}
               {%- when 'buy_buttons' -%}
                 {%- render 'buy-buttons',
                   block: block,

--- a/sections/new-product.liquid
+++ b/sections/new-product.liquid
@@ -20,6 +20,7 @@
   {{ 'component-slider.css' | asset_url | stylesheet_tag }}
   {{ 'component-rating.css' | asset_url | stylesheet_tag }}
   {{ 'component-deferred-media.css' | asset_url | stylesheet_tag }}
+  {{ 'component-size-guide.css' | asset_url | stylesheet_tag }}
 
   {% unless product.has_only_default_variant %}
     {{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
@@ -52,6 +53,7 @@
 
   <script src="{{ 'product-info.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'product-form.js' | asset_url }}" defer="defer"></script>
+  <script src="{{ 'size-guide-drawer.js' | asset_url }}" defer="defer"></script>
   {%- if product.quantity_price_breaks_configured? -%}
     <script src="{{ 'show-more.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'price-per-item.js' | asset_url }}" defer="defer"></script>
@@ -766,7 +768,7 @@
       </div>
       <!-- Size chart (original link version) -->
       <div class="size-chart" style="margin-top: 10px;">
-        {% render 'size-chart' %}
+        {% render 'product-size-guide', product: product, section_id: section.id | append: '-mobile' %}
       </div>
       <div class="product-info-accordion">
         <details>

--- a/sections/sticky-product-bar.liquid
+++ b/sections/sticky-product-bar.liquid
@@ -22,6 +22,8 @@
 {{ 'component-product-variant-picker.css' | asset_url | stylesheet_tag }}
 {{ 'component-swatch.css' | asset_url | stylesheet_tag }}
 {{ 'swatches-cheyenne.css' | asset_url | stylesheet_tag }}
+{{ 'component-size-guide.css' | asset_url | stylesheet_tag }}
+<script src="{{ 'size-guide-drawer.js' | asset_url }}" defer="defer"></script>
 
 <style>
 
@@ -292,8 +294,8 @@
     </div>
   </div>
   <div class="size-chart">
-  {% render 'size-chart' %}
-    </div>
+    {% render 'product-size-guide', product: product, section_id: section.id | append: '-sticky' %}
+  </div>
   <!-- Drawer Content -->
   <div class="drawer-content" style="background: #fff;">
     <div class="drawer-description" style="color: #333; font-size: 14px; line-height: 1.5; margin-left: 5%; margin-right: 5%; margin-top: 4rem;">

--- a/snippets/product-size-guide.liquid
+++ b/snippets/product-size-guide.liquid
@@ -1,0 +1,229 @@
+{%- comment -%}
+  Renders the size guide drawer for product pages.
+  Expects:
+  - product: Product object.
+  - section_id: Optional unique id to avoid duplicated element ids.
+{%- endcomment -%}
+{%- assign size_guide_prefix = 'size-guide-' -%}
+{%- assign prefix_length = size_guide_prefix | size -%}
+{%- assign size_guide_key = '' -%}
+{%- for tag in product.tags -%}
+  {%- assign normalized_tag = tag | strip | downcase -%}
+  {%- assign normalized_length = normalized_tag | size -%}
+  {%- if normalized_length >= prefix_length and normalized_tag | slice: 0, prefix_length == size_guide_prefix -%}
+    {%- assign remainder_length = normalized_length | minus: prefix_length -%}
+    {%- assign remainder = normalized_tag | slice: prefix_length, remainder_length -%}
+    {%- assign size_guide_key = remainder | handleize -%}
+    {%- break -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- assign size_guide_title = 'Dimensões do produto' -%}
+{%- assign size_guide_eyebrow = 'Guia de tamanhos' -%}
+{%- assign size_guide_description = 'As medidas podem apresentar pequenas variações devido ao processo de produção. A peça de roupa está medida esticada.' -%}
+{%- assign size_guide_help_text = 'Consulta como medir a peça de roupa' -%}
+{%- assign size_guide_help_link = '/pages/guia-de-tamanhos' -%}
+
+{%- assign size_guide_json = '' -%}
+{%- case size_guide_key -%}
+  {%- when 'hoodie', 'sweatshirt', 'sweat', 'casaco', 'camisola' -%}
+    {% capture size_guide_json %}
+    {
+      "title": {{ size_guide_title | json }},
+      "description": {{ size_guide_description | json }},
+      "help_text": {{ size_guide_help_text | json }},
+      "help_link": {{ size_guide_help_link | json }},
+      "base_unit": "cm",
+      "columns": ["S", "M", "L", "XL"],
+      "rows": [
+        { "label": "Peito", "values": [61, 64.5, 67, 69.5] },
+        { "label": "Comprimento à frente", "values": [68.5, 70, 71.5, 73] },
+        { "label": "Comprimento da manga", "values": [63, 64, 65, 66] },
+        { "label": "Largura das costas", "values": [55, 56.5, 58, 59.5] },
+        { "label": "Largura do braço", "values": [26, 27, 28, 29] }
+      ]
+    }
+    {% endcapture %}
+  {%- when 'tshirt', 'tee', 't-shirt', 'camiseta', 'camiseta-manga-curta' -%}
+    {% capture size_guide_json %}
+    {
+      "title": {{ size_guide_title | json }},
+      "description": {{ size_guide_description | json }},
+      "help_text": {{ size_guide_help_text | json }},
+      "help_link": {{ size_guide_help_link | json }},
+      "base_unit": "cm",
+      "columns": ["XS", "S", "M", "L", "XL"],
+      "rows": [
+        { "label": "Peito", "values": [46, 49, 52, 55, 58] },
+        { "label": "Comprimento", "values": [64, 66, 68, 70, 72] },
+        { "label": "Comprimento da manga", "values": [19, 20, 21, 22, 23] }
+      ]
+    }
+    {% endcapture %}
+  {%- when 'calcas', 'pants', 'jeans', 'trousers' -%}
+    {% capture size_guide_json %}
+    {
+      "title": {{ size_guide_title | json }},
+      "description": {{ size_guide_description | json }},
+      "help_text": {{ size_guide_help_text | json }},
+      "help_link": {{ size_guide_help_link | json }},
+      "base_unit": "cm",
+      "columns": ["34", "36", "38", "40", "42"],
+      "rows": [
+        { "label": "Cintura", "values": [66, 70, 74, 78, 82] },
+        { "label": "Anca", "values": [90, 94, 98, 102, 106] },
+        { "label": "Comprimento exterior", "values": [96, 98, 100, 102, 104] },
+        { "label": "Comprimento interior", "values": [74, 75, 76, 77, 78] }
+      ]
+    }
+    {% endcapture %}
+  {%- when 'calcado', 'calçado', 'shoes', 'sapatilhas' -%}
+    {% capture size_guide_json %}
+    {
+      "title": {{ size_guide_title | json }},
+      "description": {{ size_guide_description | json }},
+      "help_text": {{ size_guide_help_text | json }},
+      "help_link": {{ size_guide_help_link | json }},
+      "base_unit": "cm",
+      "columns": ["35", "36", "37", "38", "39", "40", "41"],
+      "rows": [
+        { "label": "Comprimento do pé", "values": [22.8, 23.5, 24.1, 24.8, 25.5, 26.1, 26.8] }
+      ]
+    }
+    {% endcapture %}
+{%- endcase -%}
+
+{%- assign size_guide = nil -%}
+{%- if size_guide_json != '' -%}
+  {%- assign size_guide = size_guide_json | strip | parse_json -%}
+{%- endif -%}
+
+{%- assign base_unit = 'cm' -%}
+{%- if size_guide and size_guide.base_unit != blank -%}
+  {%- assign base_unit = size_guide.base_unit -%}
+{%- endif -%}
+
+{%- assign has_table = false -%}
+{%- if size_guide and size_guide.rows and size_guide.rows.size > 0 -%}
+  {%- assign has_table = true -%}
+{%- endif -%}
+
+{%- assign size_guide_heading = size_guide_title -%}
+{%- if size_guide and size_guide.title != blank -%}
+  {%- assign size_guide_heading = size_guide.title -%}
+{%- endif -%}
+
+{%- assign size_guide_description_text = size_guide_description -%}
+{%- if size_guide and size_guide.description != blank -%}
+  {%- assign size_guide_description_text = size_guide.description -%}
+{%- endif -%}
+
+{%- assign size_guide_section_id = section_id | default: product.id -%}
+{%- assign drawer_id = 'SizeGuideDrawer-' | append: size_guide_section_id -%}
+
+<div class="product-size-guide" data-size-guide>
+  <button
+    type="button"
+    class="product-size-guide__trigger size-guide-link"
+    data-size-guide-trigger
+    aria-controls="{{ drawer_id }}"
+    aria-expanded="false"
+  >
+    <span class="product-size-guide__trigger-icon" aria-hidden="true">
+      {{ 'icon-ruler.svg' | inline_asset_content }}
+    </span>
+    <span>Guia de tamanhos</span>
+  </button>
+
+  <div
+    class="product-size-guide__drawer"
+    id="{{ drawer_id }}"
+    role="dialog"
+    aria-modal="true"
+    aria-hidden="true"
+    data-size-guide-drawer
+  >
+    <div class="product-size-guide__overlay" data-size-guide-close aria-hidden="true"></div>
+    <aside class="product-size-guide__panel" role="document">
+      <header class="product-size-guide__header">
+        <div>
+          <p class="product-size-guide__eyebrow">{{ size_guide_eyebrow }}</p>
+          <h2 class="product-size-guide__heading">{{ size_guide_heading }}</h2>
+        </div>
+        <button
+          type="button"
+          class="product-size-guide__close"
+          data-size-guide-close
+          aria-label="{{ 'accessibility.close' | t }}"
+        >
+          {{ 'icon-close.svg' | inline_asset_content }}
+        </button>
+      </header>
+      <div class="product-size-guide__body">
+        {%- if product.featured_media -%}
+          <div class="product-size-guide__media">
+            {{ product.featured_media | image_url: width: 800 | image_tag: class: 'product-size-guide__image', alt: product.featured_media.alt | default: product.title, loading: 'lazy' }}
+          </div>
+        {%- endif -%}
+
+        {%- if size_guide_description_text != blank -%}
+          <p class="product-size-guide__description">{{ size_guide_description_text }}</p>
+        {%- endif -%}
+
+        {%- if size_guide and size_guide.help_text != blank -%}
+          <p class="product-size-guide__help">
+            {%- if size_guide.help_link != blank -%}
+              <a class="product-size-guide__help-link" href="{{ size_guide.help_link }}">{{ size_guide.help_text }}</a>
+            {%- else -%}
+              {{ size_guide.help_text }}
+            {%- endif -%}
+          </p>
+        {%- endif -%}
+
+        {%- if has_table -%}
+          <div class="product-size-guide__unit-toggle" role="group" aria-label="Unidades">
+            <button type="button" class="product-size-guide__unit-button is-active" data-size-guide-unit data-unit="cm" aria-pressed="true">CM</button>
+            <button type="button" class="product-size-guide__unit-button" data-size-guide-unit data-unit="in" aria-pressed="false">IN</button>
+          </div>
+
+          <div
+            class="product-size-guide__table"
+            data-size-guide-table
+            data-base-unit="{{ base_unit }}"
+            data-table="{{ size_guide | json | escape }}"
+          >
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Zona</th>
+                  {%- for column in size_guide.columns -%}
+                    <th scope="col">{{ column }}</th>
+                  {%- endfor -%}
+                </tr>
+              </thead>
+              <tbody>
+                {%- for row in size_guide.rows -%}
+                  <tr>
+                    <th scope="row">{{ row.label }}</th>
+                    {%- for value in row.values -%}
+                      <td>{{ value }}</td>
+                    {%- endfor -%}
+                  </tr>
+                {%- endfor -%}
+              </tbody>
+            </table>
+          </div>
+        {%- else -%}
+          <div class="product-size-guide__empty">
+            <p>Ainda não existe uma tabela de tamanhos específica para este produto.</p>
+            <p>
+              <a class="product-size-guide__help-link" href="{{ size_guide_help_link }}">
+                Consulta o nosso guia geral de tamanhos.
+              </a>
+            </p>
+          </div>
+        {%- endif -%}
+      </div>
+    </aside>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- load the product size guide assets in the custom product layouts and sticky bar so the new drawer UI is available everywhere
- swap the legacy size chart snippet calls in those sections for the new `product-size-guide` snippet with unique IDs per context
- guard the drawer JavaScript against repeated execution when multiple sections include the script

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9248a1ec48325843d4567b5371099