### PR TITLE
Add wishlist tab to cart drawer with local storage support

### DIFF
--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -76,6 +76,49 @@ cart-drawer:not(.is-empty) .cart-drawer__collection {
   align-items: center;
 }
 
+.drawer__tabs {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 0.1rem solid rgba(var(--color-foreground), 0.15);
+}
+
+.drawer__tab {
+  position: relative;
+  padding: 0.8rem 0;
+  margin-bottom: -0.1rem;
+  font-size: 1.4rem;
+  font-weight: 600;
+  background: none;
+  border: none;
+  color: rgba(var(--color-foreground), 0.7);
+  cursor: pointer;
+  border-bottom: 0.2rem solid transparent;
+  transition: color var(--duration-default) ease, border-color var(--duration-default) ease;
+}
+
+.drawer__tab:hover,
+.drawer__tab:focus {
+  color: rgb(var(--color-foreground));
+}
+
+.drawer__tab.is-active {
+  color: rgb(var(--color-foreground));
+  border-color: rgb(var(--color-foreground));
+}
+
+.drawer__tab-panel {
+  display: none;
+}
+
+.drawer__tab-panel.is-active {
+  display: block;
+}
+
+.drawer__tab-panel[hidden] {
+  display: none;
+}
+
 .drawer__heading {
   margin: 0 0 1rem;
 }
@@ -184,9 +227,141 @@ cart-drawer {
   width: 100%;
 }
 
-cart-drawer-items {
+cart-drawer-items { 
   overflow: auto;
   flex: 1;
+}
+
+.wishlist-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 100%;
+}
+
+.wishlist-empty {
+  text-align: center;
+  color: rgba(var(--color-foreground), 0.6);
+}
+
+.wishlist-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.wishlist-item {
+  display: flex;
+  gap: 1.2rem;
+  align-items: flex-start;
+  border: 0.1rem solid rgba(var(--color-foreground), 0.12);
+  border-radius: var(--product-card-corner-radius, 0.8rem);
+  padding: 1.2rem;
+  background: rgba(var(--color-background), 0.7);
+  position: relative;
+}
+
+.wishlist-item__media {
+  flex: 0 0 8rem;
+  position: relative;
+}
+
+.wishlist-item__media img {
+  display: block;
+  width: 8rem;
+  height: 8rem;
+  object-fit: cover;
+  border-radius: 0.6rem;
+}
+
+.wishlist-item__remove {
+  position: absolute;
+  top: -0.6rem;
+  right: -0.6rem;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  width: 2.6rem;
+  height: 2.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.wishlist-item__remove svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.wishlist-item__details {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.wishlist-item__name {
+  font-size: 1.5rem;
+  text-decoration: none;
+  color: rgb(var(--color-foreground));
+}
+
+.wishlist-item__price {
+  font-weight: 600;
+}
+
+.wishlist-item__sizes {
+  margin-top: 0.8rem;
+  padding-top: 0.8rem;
+  border-top: 0.1rem solid rgba(var(--color-foreground), 0.12);
+  display: none;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.wishlist-item.show-sizes .wishlist-item__sizes {
+  display: flex;
+}
+
+.wishlist-item__size-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.wishlist-size-button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  border: 0.1rem solid rgba(var(--color-foreground), 0.4);
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.3rem;
+  transition: background var(--duration-default) ease, color var(--duration-default) ease;
+}
+
+.wishlist-size-button:hover,
+.wishlist-size-button:focus {
+  background: rgba(var(--color-foreground), 0.08);
+}
+
+.wishlist-size-button[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.wishlist-item__sizes-empty {
+  font-size: 1.3rem;
+  color: rgba(var(--color-foreground), 0.6);
+}
+
+.wishlist-item__error {
+  color: #d82c0d;
+  font-size: 1.3rem;
 }
 
 @media screen and (max-height: 650px) {

--- a/assets/wishlist.js
+++ b/assets/wishlist.js
@@ -1,105 +1,493 @@
-(() => {
-  // Using App Proxy: same-origin calls to /apps/wishlist (Shopify forwards to your server /proxy/wishlist)
-  const apiBase = "/apps/wishlist";
+(function () {
+  const STORAGE_KEY = 'shopify-wishlist';
+  const TAB_STORAGE_KEY = 'shopify-wishlist-active-tab';
+  const productCache = new Map();
+  let handlesSet = loadHandles();
 
-  // UI helpers
-  const qsa = (s, r=document) => Array.from(r.querySelectorAll(s));
-  const setActive = (btn, active) => {
-    btn.classList.toggle("is-active", !!active);
-    btn.setAttribute("aria-pressed", active ? "true" : "false");
-    btn.setAttribute("aria-label", active ? "Remove from wishlist" : "Add to wishlist");
-  };
-  const btnPayload = (btn) => ({
-    product_id: btn.dataset.productId,
-    variant_id: btn.dataset.variantId || "",
-    handle: btn.dataset.handle || "",
-    title: btn.dataset.title || "",
-    image: btn.dataset.image || ""
-  });
-
-  // Modal (login prompt)
-  function openModal(){
-    const m = document.getElementById("il-wishlist-modal"); if(!m) return;
-    m.hidden = false;
-    m.querySelectorAll("[data-il-close]").forEach(b => b.addEventListener("click", closeModal, { once:true }));
-    document.addEventListener("keydown", escClose, { once:true });
-  }
-  function closeModal(){
-    const m = document.getElementById("il-wishlist-modal"); if(!m) return;
-    m.hidden = true; document.removeEventListener("keydown", escClose);
-  }
-  function escClose(e){ if(e.key === "Escape") closeModal(); }
-
-  // API calls via App Proxy
-  async function fetchWishlist(){
-    const res = await fetch(`${apiBase}`, { method: "GET", credentials: "same-origin" });
-    if (res.status === 401) return { loggedIn:false, items:[] };
-    if (!res.ok) return { loggedIn:true, items:[] };
-    const data = await res.json();
-    return { loggedIn:true, items: data.items || [] };
-  }
-  async function addToWishlist(payload){
-    const res = await fetch(`${apiBase}`, {
-      method:"POST",
-      headers:{"Content-Type":"application/json"},
-      credentials:"same-origin",
-      body: JSON.stringify(payload)
-    });
-    if (res.status === 401) return { ok:false, auth:false };
-    return { ok:res.ok, auth:true };
-  }
-  async function removeFromWishlist(product_id, variant_id=""){
-    const url = new URL(apiBase, window.location.origin);
-    url.searchParams.set("product_id", product_id);
-    if (variant_id) url.searchParams.set("variant_id", variant_id);
-    const res = await fetch(url.toString(), { method:"DELETE", credentials:"same-origin" });
-    if (res.status === 401) return { ok:false, auth:false };
-    return { ok:res.ok, auth:true };
+  function loadHandles() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return new Set();
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return new Set(parsed.filter((value) => typeof value === 'string' && value.trim() !== ''));
+      }
+    } catch (error) {
+      console.warn('Unable to load wishlist from storage', error);
+    }
+    return new Set();
   }
 
-  async function syncStateFromServer(){
-    const { loggedIn, items } = await fetchWishlist();
-    if (!loggedIn) return; // leave all hearts empty
-    const set = new Set(items.map(i => String(i.product_id) + "::" + (i.variant_id || "")));
-    qsa(".il-wishlist-btn").forEach(btn => {
-      const key = String(btn.dataset.productId) + "::" + (btn.dataset.variantId || "");
-      setActive(btn, set.has(key));
-    });
-  }
-
-  async function onClickHeart(e){
-    const btn = e.currentTarget;
-    const active = btn.classList.contains("is-active");
-    const { product_id, variant_id } = btnPayload(btn);
-
-    // Optimistic UI
-    setActive(btn, !active);
-
-    const outcome = active
-      ? await removeFromWishlist(product_id, variant_id)
-      : await addToWishlist(btnPayload(btn));
-
-    if (!outcome.ok) {
-      setActive(btn, active); // revert
-      if (outcome.auth === false) openModal();
+  function persistHandles() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(handlesSet)));
+    } catch (error) {
+      console.warn('Unable to save wishlist to storage', error);
     }
   }
 
-  function initHearts(){
-    qsa(".il-wishlist-btn").forEach(btn => {
-      if (btn.dataset.init) return;
-      btn.dataset.init = "1";
-      btn.addEventListener("click", onClickHeart, { passive:true });
-      setActive(btn, false);
+  function getHandles() {
+    return Array.from(handlesSet);
+  }
+
+  function escapeSelector(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return value.replace(/([\0-\x1F\x7F"#%&'()*+,./:;<=>?@\[\]`{|}~])/g, '\\$1');
+  }
+
+  function updateHeartForHandle(handle) {
+    document
+      .querySelectorAll(`.wishlist-toggle[data-product-handle="${escapeSelector(handle)}"]`)
+      .forEach((button) => {
+        const isActive = handlesSet.has(handle);
+        button.classList.toggle('is-active', isActive);
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        button.setAttribute(
+          'aria-label',
+          isActive
+            ? button.getAttribute('data-label-remove') || 'Remove from wishlist'
+            : button.getAttribute('data-label-add') || 'Add to wishlist'
+        );
+      });
+  }
+
+  function updateAllHearts(root = document) {
+    root.querySelectorAll('.wishlist-toggle[data-product-handle]').forEach((button) => {
+      if (!button.hasAttribute('data-label-add')) {
+        button.setAttribute('data-label-add', button.getAttribute('aria-label') || 'Add to wishlist');
+      }
+      if (!button.hasAttribute('data-label-remove')) {
+        button.setAttribute('data-label-remove', 'Remove from wishlist');
+      }
+      const handle = button.dataset.productHandle;
+      if (!handle) return;
+      const isActive = handlesSet.has(handle);
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      button.setAttribute('aria-label', isActive ? button.dataset.labelRemove : button.dataset.labelAdd);
     });
   }
 
-  // Handle dynamic sections / SPA-like theme updates
-  const observer = new MutationObserver(() => initHearts());
-  observer.observe(document.documentElement, { childList:true, subtree:true });
+  async function fetchProduct(handle) {
+    if (productCache.has(handle)) {
+      return productCache.get(handle);
+    }
+    try {
+      const encodedHandle = encodeURIComponent(handle);
+      const response = await fetch(`${window.Shopify?.routes?.root || '/'}products/${encodedHandle}.js`);
+      if (!response.ok) throw new Error('Failed to fetch product');
+      const data = await response.json();
+      productCache.set(handle, data);
+      return data;
+    } catch (error) {
+      console.error('Unable to fetch product for wishlist', error);
+      return null;
+    }
+  }
 
-  document.addEventListener("DOMContentLoaded", async () => {
-    initHearts();
-    await syncStateFromServer();
-  });
+  function getCurrency() {
+    const drawer = document.querySelector('cart-drawer');
+    return (
+      drawer?.dataset?.currency ||
+      window.Shopify?.currency?.active ||
+      document.documentElement.getAttribute('data-shopify-currency') ||
+      'USD'
+    );
+  }
+
+  function formatPrice(cents) {
+    if (typeof Shopify !== 'undefined' && typeof Shopify.formatMoney === 'function') {
+      try {
+        if (window.theme && (window.theme.moneyFormat || window.theme.money_format)) {
+          return Shopify.formatMoney(cents, window.theme.moneyFormat || window.theme.money_format);
+        }
+        return Shopify.formatMoney(cents);
+      } catch (error) {
+        console.warn('Shopify.formatMoney failed, falling back to Intl', error);
+      }
+    }
+    const currency = getCurrency();
+    const amount = Number(cents || 0) / 100;
+    try {
+      return new Intl.NumberFormat(document.documentElement.lang || undefined, {
+        style: 'currency',
+        currency,
+      }).format(amount);
+    } catch (error) {
+      return `${amount.toFixed(2)} ${currency}`;
+    }
+  }
+
+  function getPanelStrings() {
+    const panel = document.querySelector('[data-wishlist-panel]');
+    return {
+      addLabel: panel?.dataset?.wishlistAddLabel || 'Add to cart',
+      selectSizeLabel: panel?.dataset?.wishlistSelectSizeLabel || 'Select a size',
+      outOfStockLabel: panel?.dataset?.wishlistOutOfStockLabel || 'Out of stock',
+      removeLabel: panel?.dataset?.wishlistRemoveLabel || 'Remove from wishlist',
+    };
+  }
+
+  function createSizeButton(label, variantId) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'wishlist-size-button';
+    button.dataset.wishlistVariant = String(variantId);
+    button.textContent = label;
+    return button;
+  }
+
+  function buildWishlistItem(product) {
+    const item = document.createElement('li');
+    item.className = 'wishlist-item';
+    item.dataset.handle = product.handle;
+
+    const media = document.createElement('div');
+    media.className = 'wishlist-item__media';
+
+    if (product.featured_image) {
+      const image = document.createElement('img');
+      image.src = product.featured_image;
+      image.alt = product.title;
+      image.loading = 'lazy';
+      media.appendChild(image);
+    }
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'wishlist-item__remove';
+    removeButton.dataset.wishlistRemove = product.handle;
+    removeButton.setAttribute('aria-label', getPanelStrings().removeLabel);
+    removeButton.textContent = '×';
+    media.appendChild(removeButton);
+
+    const details = document.createElement('div');
+    details.className = 'wishlist-item__details';
+
+    const nameLink = document.createElement('a');
+    nameLink.className = 'wishlist-item__name';
+    nameLink.href = product.url || `/products/${product.handle}`;
+    nameLink.textContent = product.title;
+    details.appendChild(nameLink);
+
+    const priceEl = document.createElement('div');
+    priceEl.className = 'wishlist-item__price';
+    const priceCents = product.price_min ?? product.price ?? 0;
+    priceEl.textContent = formatPrice(priceCents);
+    details.appendChild(priceEl);
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'button button--primary wishlist-item__add';
+    addButton.dataset.wishlistAdd = product.handle;
+    addButton.textContent = getPanelStrings().addLabel;
+    details.appendChild(addButton);
+
+    const sizesWrapper = document.createElement('div');
+    sizesWrapper.className = 'wishlist-item__sizes';
+    sizesWrapper.dataset.wishlistSizes = '';
+    sizesWrapper.hidden = true;
+
+    const instruction = document.createElement('p');
+    instruction.className = 'wishlist-item__sizes-label';
+    instruction.textContent = getPanelStrings().selectSizeLabel;
+    sizesWrapper.appendChild(instruction);
+
+    const sizeOptions = document.createElement('div');
+    sizeOptions.className = 'wishlist-item__size-options';
+
+    const sizeIndex = Array.isArray(product.options)
+      ? product.options.findIndex((option) => /size/i.test(option))
+      : -1;
+    const seenSizes = new Set();
+
+    const availableVariants = Array.isArray(product.variants)
+      ? product.variants.filter((variant) => variant.available)
+      : [];
+
+    if (sizeIndex !== -1) {
+      availableVariants.forEach((variant) => {
+        const label = variant.options?.[sizeIndex] || variant.title;
+        if (!label || seenSizes.has(label)) return;
+        seenSizes.add(label);
+        sizeOptions.appendChild(createSizeButton(label, variant.id));
+      });
+    } else {
+      availableVariants.forEach((variant) => {
+        sizeOptions.appendChild(createSizeButton(variant.title, variant.id));
+      });
+    }
+
+    const hasAvailableVariant = sizeOptions.querySelector('[data-wishlist-variant]');
+
+    if (!sizeOptions.children.length) {
+      const outOfStock = document.createElement('p');
+      outOfStock.className = 'wishlist-item__sizes-empty';
+      outOfStock.textContent = getPanelStrings().outOfStockLabel;
+      sizeOptions.appendChild(outOfStock);
+    }
+
+    sizesWrapper.appendChild(sizeOptions);
+    details.appendChild(sizesWrapper);
+
+    if (!hasAvailableVariant) {
+      addButton.disabled = true;
+    }
+
+    const error = document.createElement('p');
+    error.className = 'wishlist-item__error';
+    error.hidden = true;
+    details.appendChild(error);
+
+    item.appendChild(media);
+    item.appendChild(details);
+
+    return item;
+  }
+
+  function clearWishlistList(listElement) {
+    while (listElement.firstChild) {
+      listElement.removeChild(listElement.firstChild);
+    }
+  }
+
+  async function renderWishlistDrawer() {
+    const drawer = document.querySelector('cart-drawer');
+    if (!drawer) return;
+    const panel = drawer.querySelector('[data-wishlist-panel]');
+    const listElement = panel?.querySelector('[data-wishlist-items]');
+    const emptyElement = panel?.querySelector('[data-wishlist-empty]');
+
+    if (!panel || !listElement || !emptyElement) return;
+
+    const handles = getHandles();
+    if (!handles.length) {
+      clearWishlistList(listElement);
+      emptyElement.hidden = false;
+      panel.setAttribute('data-count', '0');
+      return;
+    }
+
+    emptyElement.hidden = true;
+    clearWishlistList(listElement);
+
+    const products = await Promise.all(handles.map((handle) => fetchProduct(handle)));
+    products.forEach((product) => {
+      if (!product) return;
+      const item = buildWishlistItem(product);
+      listElement.appendChild(item);
+    });
+
+    if (!listElement.children.length) {
+      emptyElement.hidden = false;
+      panel.setAttribute('data-count', '0');
+    } else {
+      panel.setAttribute('data-count', String(listElement.children.length));
+    }
+  }
+
+  function toggleWishlist(handle) {
+    if (handlesSet.has(handle)) {
+      handlesSet.delete(handle);
+    } else {
+      handlesSet.add(handle);
+    }
+    persistHandles();
+    updateHeartForHandle(handle);
+    renderWishlistDrawer();
+  }
+
+  function removeFromWishlist(handle) {
+    if (!handlesSet.has(handle)) return;
+    handlesSet.delete(handle);
+    persistHandles();
+    updateHeartForHandle(handle);
+    renderWishlistDrawer();
+  }
+
+  function setActiveTab(tabName) {
+    const drawer = document.querySelector('cart-drawer');
+    if (!drawer) return;
+    const buttons = drawer.querySelectorAll('[data-drawer-tab]');
+    const panels = drawer.querySelectorAll('[data-drawer-panel]');
+    let targetName = tabName;
+    if (!Array.from(buttons).some((btn) => btn.dataset.drawerTab === targetName)) {
+      targetName = 'cart';
+    }
+    buttons.forEach((button) => {
+      const isActive = button.dataset.drawerTab === targetName;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.setAttribute('tabindex', isActive ? '0' : '-1');
+    });
+    panels.forEach((panel) => {
+      const isActive = panel.dataset.drawerPanel === targetName;
+      panel.classList.toggle('is-active', isActive);
+      panel.toggleAttribute('hidden', !isActive);
+    });
+    try {
+      localStorage.setItem(TAB_STORAGE_KEY, targetName);
+    } catch (error) {
+      console.warn('Unable to persist cart drawer tab selection', error);
+    }
+  }
+
+  function restoreActiveTab() {
+    try {
+      const stored = localStorage.getItem(TAB_STORAGE_KEY);
+      if (stored) {
+        setActiveTab(stored);
+        return;
+      }
+    } catch (error) {
+      console.warn('Unable to read cart drawer tab state', error);
+    }
+    setActiveTab('cart');
+  }
+
+  function showSizeSelector(item) {
+    if (!item) return;
+    document.querySelectorAll('.wishlist-item.show-sizes').forEach((active) => {
+      if (active !== item) {
+        active.classList.remove('show-sizes');
+        const sizes = active.querySelector('[data-wishlist-sizes]');
+        if (sizes) sizes.hidden = true;
+      }
+    });
+    item.classList.toggle('show-sizes');
+    const sizes = item.querySelector('[data-wishlist-sizes]');
+    if (sizes) {
+      sizes.hidden = !item.classList.contains('show-sizes');
+    }
+  }
+
+  function setWishlistError(item, message) {
+    const error = item?.querySelector('.wishlist-item__error');
+    if (!error) return;
+    if (message) {
+      error.textContent = message;
+      error.hidden = false;
+    } else {
+      error.textContent = '';
+      error.hidden = true;
+    }
+  }
+
+  async function addVariantToCart(variantId, item) {
+    const cart = document.querySelector('cart-drawer') || document.querySelector('cart-notification');
+    const config = fetchConfig('javascript');
+    config.headers['X-Requested-With'] = 'XMLHttpRequest';
+    delete config.headers['Content-Type'];
+
+    const formData = new FormData();
+    formData.append('id', variantId);
+    formData.append('quantity', 1);
+
+    if (cart && typeof cart.getSectionsToRender === 'function') {
+      const sections = cart.getSectionsToRender();
+      formData.append('sections', sections.map((section) => section.id));
+      formData.append('sections_url', window.location.pathname);
+      if (typeof cart.setActiveElement === 'function') {
+        cart.setActiveElement(document.activeElement);
+      }
+    }
+
+    config.body = formData;
+
+    try {
+      const response = await fetch(`${routes.cart_add_url}`, config);
+      const data = await response.json();
+      if (data.status && data.status !== 200) {
+        throw new Error(data.description || 'Unable to add to cart');
+      }
+      if (cart && typeof cart.renderContents === 'function') {
+        cart.renderContents(data);
+      } else {
+        window.location = window.routes.cart_url;
+      }
+      publish(PUB_SUB_EVENTS.cartUpdate, { source: 'wishlist', cartData: data, productVariantId: variantId });
+      restoreActiveTab();
+      renderWishlistDrawer();
+      if (item) {
+        item.classList.remove('show-sizes');
+        const sizes = item.querySelector('[data-wishlist-sizes]');
+        if (sizes) sizes.hidden = true;
+        setWishlistError(item, '');
+      }
+    } catch (error) {
+      console.error('Unable to add wishlist variant to cart', error);
+      if (item) {
+        setWishlistError(item, error.message || 'Unable to add to cart.');
+      }
+    }
+  }
+
+  function handleDocumentClick(event) {
+    const heartButton = event.target.closest('.wishlist-toggle');
+    if (heartButton) {
+      event.preventDefault();
+      const handle = heartButton.dataset.productHandle;
+      if (handle) {
+        toggleWishlist(handle);
+      }
+      return;
+    }
+
+    const tabButton = event.target.closest('[data-drawer-tab]');
+    if (tabButton) {
+      event.preventDefault();
+      setActiveTab(tabButton.dataset.drawerTab);
+      return;
+    }
+
+    const removeButton = event.target.closest('[data-wishlist-remove]');
+    if (removeButton) {
+      event.preventDefault();
+      const handle = removeButton.dataset.wishlistRemove;
+      if (handle) {
+        removeFromWishlist(handle);
+      }
+      return;
+    }
+
+    const addButton = event.target.closest('[data-wishlist-add]');
+    if (addButton) {
+      event.preventDefault();
+      const item = addButton.closest('.wishlist-item');
+      showSizeSelector(item);
+      return;
+    }
+
+    const variantButton = event.target.closest('[data-wishlist-variant]');
+    if (variantButton) {
+      event.preventDefault();
+      const variantId = variantButton.dataset.wishlistVariant;
+      if (!variantId) return;
+      const item = variantButton.closest('.wishlist-item');
+      setWishlistError(item, '');
+      variantButton.disabled = true;
+      addVariantToCart(variantId, item).finally(() => {
+        variantButton.disabled = false;
+      });
+    }
+  }
+
+  function handleSectionLoad(event) {
+    updateAllHearts(event.target);
+    renderWishlistDrawer();
+    restoreActiveTab();
+  }
+
+  function init() {
+    updateAllHearts();
+    restoreActiveTab();
+    renderWishlistDrawer();
+  }
+
+  document.addEventListener('click', handleDocumentClick);
+  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('shopify:section:load', handleSectionLoad);
 })();
+

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -11,7 +11,50 @@
 
 .product-card { position: relative; }
 
-  
+  .card__media {
+    position: relative;
+  }
+
+  .product-card__wishlist {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 5;
+  }
+
+  .wishlist-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.2rem;
+    height: 3.2rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(255, 255, 255, 0.85);
+    color: rgb(var(--color-foreground));
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .wishlist-toggle:hover,
+  .wishlist-toggle:focus {
+    transform: scale(1.05);
+    box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.15);
+  }
+
+  .wishlist-toggle svg {
+    width: 1.8rem;
+    height: 1.8rem;
+    fill: transparent;
+    stroke: currentColor;
+    stroke-width: 1.5;
+    transition: fill 0.2s ease;
+  }
+
+  .wishlist-toggle.is-active svg {
+    fill: currentColor;
+  }
+
   .card__content {
     width: 100%;
   }
@@ -181,6 +224,19 @@
       >
        {% if card_product.featured_media %}
   <div class="card__media swiper-container">
+    <div class="product-card__wishlist">
+      <button
+        type="button"
+        class="wishlist-toggle"
+        aria-pressed="false"
+        aria-label="{{ 'general.wishlist.add' | t | default: 'Add to wishlist' }}"
+        data-product-handle="{{ card_product.handle }}"
+        data-label-add="{{ 'general.wishlist.add' | t | default: 'Add to wishlist' }}"
+        data-label-remove="{{ 'general.wishlist.remove' | t | default: 'Remove from wishlist' }}"
+      >
+        {{- 'icon-heart.svg' | inline_asset_content -}}
+      </button>
+    </div>
     <div class="swiper-wrapper">
       {% for media in card_product.media %}
         {% if media.preview_image != blank %}

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -10,6 +10,7 @@
 
 <script src="{{ 'cart.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'quantity-popover.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'wishlist.js' | asset_url }}" defer="defer"></script>
 
 <style>
   .drawer {
@@ -17,7 +18,10 @@
   }
 </style>
 
-<cart-drawer class="drawer{% if cart == empty %} is-empty{% endif %}">
+<cart-drawer
+  class="drawer{% if cart == empty %} is-empty{% endif %}"
+  data-currency="{{ cart.currency.iso_code | default: shop.currency }}"
+>
   <div id="CartDrawer" class="cart-drawer">
     <div id="CartDrawer-Overlay" class="cart-drawer__overlay"></div>
     <div
@@ -78,126 +82,157 @@
           </span>
         </button>
       </div>
-      <cart-drawer-items
-        {% if cart == empty %}
-          class=" is-empty"
-        {% endif %}
-      >
-        <form
-          action="{{ routes.cart_url }}"
-          id="CartDrawer-Form"
-          class="cart__contents cart-drawer__form"
-          method="post"
+      <div class="drawer__tabs" role="tablist">
+        <button
+          type="button"
+          class="drawer__tab is-active"
+          data-drawer-tab="cart"
+          id="CartDrawerTabButton-cart"
+          aria-controls="CartDrawerTabPanel-cart"
+          aria-selected="true"
+          role="tab"
         >
-          <div id="CartDrawer-CartItems" class="drawer__contents js-contents">
-            {%- if cart != empty -%}
-              <div class="drawer__cart-items-wrapper">
-                <table class="cart-items" role="table">
-                  <thead role="rowgroup">
-                    <tr role="row">
-                      <th id="CartDrawer-ColumnProductImage" role="columnheader">
-                        <span class="visually-hidden">{{ 'sections.cart.headings.image' | t }}</span>
-                      </th>
-                      <th
-                        id="CartDrawer-ColumnProduct"
-                        class="caption-with-letter-spacing"
-                        scope="col"
-                        role="columnheader"
-                      >
-                        {{ 'sections.cart.headings.product' | t }}
-                      </th>
-                      <th
-                        id="CartDrawer-ColumnTotal"
-                        class="right caption-with-letter-spacing"
-                        scope="col"
-                        role="columnheader"
-                      >
-                        {{ 'sections.cart.headings.total' | t }}
-                      </th>
-                      <th id="CartDrawer-ColumnQuantity" role="columnheader">
-                        <span class="visually-hidden">{{ 'sections.cart.headings.quantity' | t }}</span>
-                      </th>
-                    </tr>
-                  </thead>
+          {{ 'sections.cart.title' | t }}
+        </button>
+        <button
+          type="button"
+          class="drawer__tab"
+          data-drawer-tab="wishlist"
+          id="CartDrawerTabButton-wishlist"
+          aria-controls="CartDrawerTabPanel-wishlist"
+          aria-selected="false"
+          role="tab"
+        >
+          {{ 'general.wishlist.title' | t | default: 'Wishlist' }}
+        </button>
+      </div>
+      <div
+        id="CartDrawerTabPanel-cart"
+        class="drawer__tab-panel is-active"
+        data-drawer-panel="cart"
+        role="tabpanel"
+        aria-labelledby="CartDrawerTabButton-cart"
+      >
+        <cart-drawer-items
+          {% if cart == empty %}
+            class=" is-empty"
+          {% endif %}
+        >
+          <form
+            action="{{ routes.cart_url }}"
+            id="CartDrawer-Form"
+            class="cart__contents cart-drawer__form"
+            method="post"
+          >
+            <div id="CartDrawer-CartItems" class="drawer__contents js-contents">
+              {%- if cart != empty -%}
+                <div class="drawer__cart-items-wrapper">
+                  <table class="cart-items" role="table">
+                    <thead role="rowgroup">
+                      <tr role="row">
+                        <th id="CartDrawer-ColumnProductImage" role="columnheader">
+                          <span class="visually-hidden">{{ 'sections.cart.headings.image' | t }}</span>
+                        </th>
+                        <th
+                          id="CartDrawer-ColumnProduct"
+                          class="caption-with-letter-spacing"
+                          scope="col"
+                          role="columnheader"
+                        >
+                          {{ 'sections.cart.headings.product' | t }}
+                        </th>
+                        <th
+                          id="CartDrawer-ColumnTotal"
+                          class="right caption-with-letter-spacing"
+                          scope="col"
+                          role="columnheader"
+                        >
+                          {{ 'sections.cart.headings.total' | t }}
+                        </th>
+                        <th id="CartDrawer-ColumnQuantity" role="columnheader">
+                          <span class="visually-hidden">{{ 'sections.cart.headings.quantity' | t }}</span>
+                        </th>
+                      </tr>
+                    </thead>
 
-                  <tbody role="rowgroup">
-                    {%- for item in cart.items -%}
-                      <tr id="CartDrawer-Item-{{ item.index | plus: 1 }}" class="cart-item" role="row">
-                        <td class="cart-item__media" role="cell" headers="CartDrawer-ColumnProductImage">
-                          {% if item.image %}
-                            {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
-                            <a href="{{ item.url }}" class="cart-item__link" tabindex="-1" aria-hidden="true"> </a>
-                            <img
-                              class="cart-item__image"
-                              src="{{ item.image | image_url: width: 300 }}"
-                              alt="{{ item.image.alt | escape }}"
-                              loading="lazy"
-                              width="150"
-                              height="{{ 150 | divided_by: item.image.aspect_ratio | ceil }}"
-                            >
-                          {% endif %}
-                        </td>
+                    <tbody role="rowgroup">
+                      {%- for item in cart.items -%}
+                        <tr id="CartDrawer-Item-{{ item.index | plus: 1 }}" class="cart-item" role="row">
+                          <td class="cart-item__media" role="cell" headers="CartDrawer-ColumnProductImage">
+                            {% if item.image %}
+                              {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
+                              <a href="{{ item.url }}" class="cart-item__link" tabindex="-1" aria-hidden="true"> </a>
+                              <img
+                                class="cart-item__image"
+                                src="{{ item.image | image_url: width: 300 }}"
+                                alt="{{ item.image.alt | escape }}"
+                                loading="lazy"
+                                width="150"
+                                height="{{ 150 | divided_by: item.image.aspect_ratio | ceil }}"
+                              >
+                            {% endif %}
+                          </td>
 
-                        <td class="cart-item__details" role="cell" headers="CartDrawer-ColumnProduct">
-                          {%- if settings.show_vendor -%}
-                            <p class="caption-with-letter-spacing light">{{ item.product.vendor }}</p>
-                          {%- endif -%}
+                          <td class="cart-item__details" role="cell" headers="CartDrawer-ColumnProduct">
+                            {%- if settings.show_vendor -%}
+                              <p class="caption-with-letter-spacing light">{{ item.product.vendor }}</p>
+                            {%- endif -%}
 
-                          <a href="{{ item.url }}" class="cart-item__name h4 break">
-                            {{- item.product.title | escape -}}
-                          </a>
+                            <a href="{{ item.url }}" class="cart-item__name h4 break">
+                              {{- item.product.title | escape -}}
+                            </a>
 
-                          {%- if item.original_price != item.final_price -%}
-                            <div class="cart-item__discounted-prices">
-                              <span class="visually-hidden">
-                                {{ 'products.product.price.regular_price' | t }}
-                              </span>
-                              <s class="cart-item__old-price product-option">
-                                {{- item.original_price | money -}}
-                              </s>
-                              <span class="visually-hidden">
-                                {{ 'products.product.price.sale_price' | t }}
-                              </span>
-                              <strong class="cart-item__final-price product-option">
-                                {{ item.final_price | money }}
-                              </strong>
-                            </div>
-                          {%- else -%}
-                            <div class="product-option">
-                              {{ item.original_price | money }}
-                            </div>
-                          {%- endif -%}
+                            {%- if item.original_price != item.final_price -%}
+                              <div class="cart-item__discounted-prices">
+                                <span class="visually-hidden">
+                                  {{ 'products.product.price.regular_price' | t }}
+                                </span>
+                                <s class="cart-item__old-price product-option">
+                                  {{- item.original_price | money -}}
+                                </s>
+                                <span class="visually-hidden">
+                                  {{ 'products.product.price.sale_price' | t }}
+                                </span>
+                                <strong class="cart-item__final-price product-option">
+                                  {{ item.final_price | money }}
+                                </strong>
+                              </div>
+                            {%- else -%}
+                              <div class="product-option">
+                                {{ item.original_price | money }}
+                              </div>
+                            {%- endif -%}
 
-                          {%- if item.product.has_only_default_variant == false
-                            or item.properties.size != 0
-                            or item.selling_plan_allocation != null
-                          -%}
-                            <dl>
-                              {%- if item.product.has_only_default_variant == false -%}
-                                {%- for option in item.options_with_values -%}
-                                  <div class="product-option">
-                                    <dt>{{ option.name }}:</dt>
-                                    <dd>
-                                      {{ option.value -}}
-                                      {%- unless forloop.last %}, {% endunless %}
-                                    </dd>
-                                  </div>
-                                {%- endfor -%}
-                              {%- endif -%}
+                            {%- if item.product.has_only_default_variant == false
+                              or item.properties.size != 0
+                              or item.selling_plan_allocation != null
+                            -%}
+                              <dl>
+                                {%- if item.product.has_only_default_variant == false -%}
+                                  {%- for option in item.options_with_values -%}
+                                    <div class="product-option">
+                                      <dt>{{ option.name }}:</dt>
+                                      <dd>
+                                        {{ option.value -}}
+                                        {%- unless forloop.last %}, {% endunless %}
+                                      </dd>
+                                    </div>
+                                  {%- endfor -%}
+                                {%- endif -%}
 
-                              {%- for property in item.properties -%}
-                                {%- assign property_first_char = property.first | slice: 0 -%}
-                                {%- if property.last != blank and property_first_char != '_' -%}
-                                  <div class="product-option">
-                                    <dt>{{ property.first }}:</dt>
-                                    <dd>
-                                      {%- if property.last contains '/uploads/' -%}
-                                        <a
-                                          href="{{ property.last }}"
-                                          class="link"
-                                          target="_blank"
-                                          aria-describedby="a11y-new-window-message"
-                                        >
+                                {%- for property in item.properties -%}
+                                  {%- assign property_first_char = property.first | slice: 0 -%}
+                                  {%- if property.last != blank and property_first_char != '_' -%}
+                                    <div class="product-option">
+                                      <dt>{{ property.first }}:</dt>
+                                      <dd>
+                                        {%- if property.last contains '/uploads/' -%}
+                                          <a
+                                            href="{{ property.last }}"
+                                            class="link"
+                                            target="_blank"
+                                            aria-describedby="a11y-new-window-message"
+                                          >
                                           {{ property.last | split: '/' | last }}
                                         </a>
                                       {%- else -%}
@@ -458,6 +493,29 @@
           <div id="CartDrawer-CartErrors" role="alert"></div>
         </form>
       </cart-drawer-items>
+      </div>
+      <div
+        id="CartDrawerTabPanel-wishlist"
+        class="drawer__tab-panel"
+        data-drawer-panel="wishlist"
+        role="tabpanel"
+        aria-labelledby="CartDrawerTabButton-wishlist"
+        hidden
+      >
+        <div
+          class="wishlist-panel"
+          data-wishlist-panel
+          data-wishlist-add-label="{{ 'products.product.add_to_cart' | t }}"
+          data-wishlist-select-size-label="{{ 'products.product.select_options' | t | default: 'Select a size' }}"
+          data-wishlist-out-of-stock-label="{{ 'products.product.sold_out' | t }}"
+          data-wishlist-remove-label="{{ 'general.wishlist.remove' | t | default: 'Remove from wishlist' }}"
+        >
+          <div class="wishlist-empty" data-wishlist-empty>
+            <p>{{ 'general.wishlist.empty' | t | default: 'Your wishlist is empty.' }}</p>
+          </div>
+          <ul class="wishlist-items" data-wishlist-items role="list"></ul>
+        </div>
+      </div>
       <div class="drawer__footer">
         {%- if settings.show_cart_note -%}
           <details id="Details-CartDrawer">


### PR DESCRIPTION
## Summary
- add tab navigation and wishlist panel markup to the cart drawer alongside cart content
- surface wishlist toggle buttons on product cards and style the drawer wishlist view
- implement client-side wishlist management with localStorage syncing, tab persistence, and add-to-cart integration

## Testing
- not run (not specified)


------
https://chatgpt.com/codex/tasks/task_e_68ca91f94aa48325a13bb29aa4983590