### PR TITLE
Add cart drawer wishlist with local storage support

### DIFF
--- a/assets/cart-drawer.js
+++ b/assets/cart-drawer.js
@@ -5,6 +5,18 @@ class CartDrawer extends HTMLElement {
     this.addEventListener('keyup', (evt) => evt.code === 'Escape' && this.close());
     this.querySelector('#CartDrawer-Overlay').addEventListener('click', this.close.bind(this));
     this.setHeaderCartIconAccessibility();
+
+    this.activeTab = 'cart';
+    this.handleWishlistUpdate = this.handleWishlistUpdate.bind(this);
+    document.addEventListener('theme:wishlist:updated', this.handleWishlistUpdate);
+  }
+
+  connectedCallback() {
+    this.initializeDrawerUI();
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('theme:wishlist:updated', this.handleWishlistUpdate);
   }
 
   setHeaderCartIconAccessibility() {
@@ -85,6 +97,7 @@ class CartDrawer extends HTMLElement {
       sectionElement.innerHTML = this.getSectionInnerHTML(parsedState.sections[section.id], section.selector);
     });
 
+    this.initializeDrawerUI();
     setTimeout(() => {
       this.querySelector('#CartDrawer-Overlay').addEventListener('click', this.close.bind(this));
       this.open();
@@ -109,6 +122,358 @@ class CartDrawer extends HTMLElement {
 
   getSectionDOM(html, selector = '.shopify-section') {
     return new DOMParser().parseFromString(html, 'text/html').querySelector(selector);
+  }
+
+  initializeDrawerUI() {
+    this.setupTabs();
+    this.setupWishlistPanel();
+    this.renderWishlist();
+  }
+
+  setupTabs() {
+    if (this.tabButtons) {
+      this.tabButtons.forEach((button) => button.removeEventListener('click', this.onTabClick));
+    }
+
+    this.tabButtons = Array.from(this.querySelectorAll('[data-tab-target]'));
+    this.tabPanels = Array.from(this.querySelectorAll('[data-tab-panel]'));
+
+    if (!this.onTabClick) {
+      this.onTabClick = (event) => {
+        const target = event.currentTarget?.dataset?.tabTarget;
+        this.setActiveTab(target);
+      };
+    }
+
+    if (this.tabButtons) {
+      this.tabButtons.forEach((button) => button.addEventListener('click', this.onTabClick));
+    }
+
+    if (!this.activeTab) {
+      this.activeTab = 'cart';
+    }
+
+    this.setActiveTab(this.activeTab, { focus: false });
+  }
+
+  setActiveTab(tab, { focus = false } = {}) {
+    if (!this.tabButtons || this.tabButtons.length === 0) return;
+
+    const availableTabs = this.tabButtons.map((button) => button.dataset.tabTarget);
+    const nextTab = availableTabs.includes(tab) ? tab : availableTabs[0];
+    this.activeTab = nextTab;
+
+    this.tabButtons.forEach((button) => {
+      const isActive = button.dataset.tabTarget === nextTab;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      if (isActive && focus) {
+        button.focus();
+      }
+    });
+
+    if (this.tabPanels) {
+      this.tabPanels.forEach((panel) => {
+        const isActive = panel.dataset.tabPanel === nextTab;
+        panel.classList.toggle('is-active', isActive);
+        panel.toggleAttribute('hidden', !isActive);
+      });
+    }
+  }
+
+  setupWishlistPanel() {
+    const panel = this.querySelector('[data-tab-panel="wishlist"]');
+
+    if (this.wishlistPanel && this.onWishlistClick) {
+      this.wishlistPanel.removeEventListener('click', this.onWishlistClick);
+    }
+
+    this.wishlistPanel = panel;
+
+    if (!this.onWishlistClick) {
+      this.onWishlistClick = (event) => this.handleWishlistClick(event);
+    }
+
+    if (panel) {
+      panel.addEventListener('click', this.onWishlistClick);
+    }
+  }
+
+  handleWishlistClick(event) {
+    const target = event.target;
+    if (!target) return;
+
+    const removeButton = target.closest('[data-wishlist-remove]');
+    if (removeButton) {
+      event.preventDefault();
+      const productId = removeButton.dataset.productId || removeButton.closest('[data-wishlist-item]')?.dataset.productId;
+      if (window.ThemeWishlist && productId) {
+        window.ThemeWishlist.removeItem(productId);
+      }
+      return;
+    }
+
+    const addButton = target.closest('[data-wishlist-add]');
+    if (addButton) {
+      event.preventDefault();
+      this.openSizePicker(addButton);
+      return;
+    }
+
+    const sizeButton = target.closest('[data-wishlist-size]');
+    if (sizeButton) {
+      event.preventDefault();
+      this.onWishlistSize(sizeButton);
+    }
+  }
+
+  openSizePicker(button) {
+    const item = button.closest('[data-wishlist-item]');
+    if (!item) return;
+    const picker = item.querySelector('[data-wishlist-sizes]');
+    if (!picker) return;
+
+    const willOpen = !picker.classList.contains('is-open');
+    picker.classList.toggle('is-open', willOpen);
+    picker.toggleAttribute('hidden', !willOpen);
+    button.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+  }
+
+  onWishlistSize(button) {
+    const variantId = button.dataset.variantId;
+    const item = button.closest('[data-wishlist-item]');
+    if (!item || !variantId) return;
+
+    const productId = item.dataset.productId;
+    this.addWishlistVariantToCart(variantId, productId, item, button);
+  }
+
+  async addWishlistVariantToCart(variantId, productId, item, triggerButton) {
+    const errorElement = item.querySelector('[data-wishlist-error]');
+    if (errorElement) {
+      errorElement.textContent = '';
+      errorElement.hidden = true;
+    }
+
+    if (triggerButton) {
+      triggerButton.classList.add('is-loading');
+      triggerButton.setAttribute('aria-disabled', 'true');
+    }
+
+    try {
+      const config = fetchConfig();
+      config.headers['X-Requested-With'] = 'XMLHttpRequest';
+      config.body = JSON.stringify({
+        id: variantId,
+        quantity: 1,
+        sections: this.getSectionsToRender().map((section) => section.id),
+        sections_url: window.location.pathname,
+      });
+
+      const response = await fetch(`${routes.cart_add_url}`, config);
+      const data = await response.json();
+
+      if (data.status) {
+        if (errorElement) {
+          errorElement.textContent = data.message || data.description || 'Unable to add this item to your cart.';
+          errorElement.hidden = false;
+        }
+        return;
+      }
+
+      if (window.ThemeWishlist && productId) {
+        window.ThemeWishlist.removeItem(productId);
+      }
+
+      this.setActiveTab('cart');
+      this.renderContents(data);
+    } catch (error) {
+      console.error(error);
+      if (errorElement) {
+        errorElement.textContent = 'Something went wrong. Please try again.';
+        errorElement.hidden = false;
+      }
+    } finally {
+      if (triggerButton) {
+        triggerButton.classList.remove('is-loading');
+        triggerButton.removeAttribute('aria-disabled');
+      }
+    }
+  }
+
+  async renderWishlist() {
+    const container = this.querySelector('[data-wishlist-container]');
+    const badge = this.querySelector('[data-wishlist-count]');
+    const items = this.getWishlistItems();
+
+    if (badge) {
+      badge.textContent = items.length;
+    }
+
+    if (!container) return;
+
+    if (!items.length) {
+      container.innerHTML = '<p class="cart-drawer__wishlist-empty">Your wishlist is empty.</p>';
+      return;
+    }
+
+    const token = Symbol('wishlist-render');
+    this.wishlistRenderToken = token;
+    container.innerHTML = '<p class="cart-drawer__wishlist-loading">Loading your wishlist…</p>';
+
+    const fragments = await Promise.all(
+      items.map(async (item) => {
+        try {
+          if (!window.ThemeWishlist || typeof window.ThemeWishlist.fetchProduct !== 'function') {
+            return this.buildWishlistItem(item, null);
+          }
+          const product = await window.ThemeWishlist.fetchProduct(item.handle);
+          return this.buildWishlistItem(item, product);
+        } catch (error) {
+          console.error(error);
+          return this.buildWishlistItem(item, null, { unavailable: true });
+        }
+      })
+    );
+
+    if (this.wishlistRenderToken !== token) return;
+
+    container.innerHTML = fragments.join('');
+  }
+
+  getWishlistItems() {
+    if (!window.ThemeWishlist || typeof window.ThemeWishlist.getItems !== 'function') {
+      return [];
+    }
+    return window.ThemeWishlist.getItems();
+  }
+
+  buildWishlistItem(item, product, options = {}) {
+    const productTitle = item.title || product?.title || '';
+    const title = this.escapeHtml(productTitle);
+    const productUrl = item.url || (product?.handle ? `/products/${product.handle}` : '#');
+    const url = this.escapeHtml(productUrl);
+    const imageSrc = item.image || product?.featured_image || product?.images?.[0] || '';
+    const image = this.escapeHtml(imageSrc);
+    const price = item.price || this.formatPrice(product?.price);
+
+    const variantOptions = this.getVariantSizeOptions(product);
+
+    if (options.unavailable || variantOptions.variants.length === 0) {
+      return `
+        <div class="cart-drawer__wishlist-item" data-wishlist-item data-product-id="${this.escapeHtml(item.productId)}" data-handle="${this.escapeHtml(item.handle || '')}">
+          <div class="cart-drawer__wishlist-media">
+            ${image ? `<a href="${url}" class="cart-drawer__wishlist-image-link"><img class="cart-drawer__wishlist-image" src="${image}" alt="${title}" loading="lazy"></a>` : ''}
+            <button type="button" class="button button--tertiary cart-drawer__wishlist-remove" data-wishlist-remove data-product-id="${this.escapeHtml(item.productId)}">Remove</button>
+          </div>
+          <div class="cart-drawer__wishlist-details">
+            <a class="cart-drawer__wishlist-title" href="${url}">${title}</a>
+            ${price ? `<p class="cart-drawer__wishlist-price">${price}</p>` : ''}
+            <p class="cart-drawer__wishlist-error">This product is currently unavailable.</p>
+          </div>
+        </div>
+      `;
+    }
+
+    const sizeButtons = variantOptions.variants
+      .map(
+        (variant) => `
+          <button type="button" class="cart-drawer__wishlist-size-button" data-wishlist-size data-variant-id="${variant.id}" data-product-id="${this.escapeHtml(item.productId)}">
+            ${this.escapeHtml(variant.label)}
+          </button>
+        `
+      )
+      .join('');
+
+    return `
+      <div class="cart-drawer__wishlist-item" data-wishlist-item data-product-id="${this.escapeHtml(item.productId)}" data-handle="${this.escapeHtml(item.handle || '')}">
+        <div class="cart-drawer__wishlist-media">
+          ${image ? `<a href="${url}" class="cart-drawer__wishlist-image-link"><img class="cart-drawer__wishlist-image" src="${image}" alt="${title}" loading="lazy"></a>` : ''}
+          <button type="button" class="button button--tertiary cart-drawer__wishlist-remove" data-wishlist-remove data-product-id="${this.escapeHtml(item.productId)}">Remove</button>
+        </div>
+        <div class="cart-drawer__wishlist-details">
+          <a class="cart-drawer__wishlist-title" href="${url}">${title}</a>
+          ${price ? `<p class="cart-drawer__wishlist-price">${price}</p>` : ''}
+          <div class="cart-drawer__wishlist-actions">
+            <button type="button" class="button button--primary" data-wishlist-add aria-expanded="false" data-product-id="${this.escapeHtml(item.productId)}">
+              Add to cart
+            </button>
+            <div class="cart-drawer__wishlist-sizes" data-wishlist-sizes hidden>
+              <p class="cart-drawer__wishlist-size-label">Select a size:</p>
+              <div class="cart-drawer__wishlist-size-grid">
+                ${sizeButtons}
+              </div>
+              <p class="cart-drawer__wishlist-error" data-wishlist-error hidden></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  getVariantSizeOptions(product) {
+    const result = { variants: [] };
+    if (!product || !Array.isArray(product?.variants)) {
+      return result;
+    }
+
+    const options = Array.isArray(product.options) ? product.options : [];
+    const sizeIndex = options.findIndex((option) => /size/i.test(option));
+    const seen = new Set();
+
+    product.variants.forEach((variant) => {
+      if (!variant.available) return;
+      const label = sizeIndex >= 0 ? variant.options[sizeIndex] : variant.title;
+      const key = label || variant.id;
+      if (seen.has(key)) return;
+      seen.add(key);
+      result.variants.push({ id: variant.id, label: label || 'Default' });
+    });
+
+    if (result.variants.length === 0 && product.variants.length > 0) {
+      const variant = product.variants[0];
+      result.variants.push({ id: variant.id, label: variant.title || 'Default' });
+    }
+
+    return result;
+  }
+
+  escapeHtml(value) {
+    if (value == null) return '';
+    return String(value).replace(/[&<>"']/g, (char) => {
+      const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+      };
+      return map[char] || char;
+    });
+  }
+
+  formatPrice(cents) {
+    if (typeof cents !== 'number') return '';
+    if (typeof Shopify !== 'undefined' && typeof Shopify.formatMoney === 'function') {
+      const moneyFormat = window.theme?.moneyFormat || window.shopMoneyFormat || window.moneyFormat;
+      if (moneyFormat) {
+        return Shopify.formatMoney(cents, moneyFormat);
+      }
+    }
+
+    const currency = (window.Shopify && window.Shopify.currency && window.Shopify.currency.active) || 'USD';
+    try {
+      return new Intl.NumberFormat(document.documentElement.lang || 'en', {
+        style: 'currency',
+        currency,
+      }).format(cents / 100);
+    } catch (error) {
+      return (cents / 100).toFixed(2);
+    }
+  }
+
+  handleWishlistUpdate() {
+    this.renderWishlist();
   }
 
   setActiveElement(element) {

--- a/assets/component-cart-drawer.css
+++ b/assets/component-cart-drawer.css
@@ -165,6 +165,171 @@ cart-drawer {
   flex-wrap: wrap;
 }
 
+.drawer__tabs {
+  display: flex;
+  gap: 1rem;
+  margin: 1.6rem 0 2rem;
+}
+
+.drawer__tab {
+  flex: 1 1 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.8rem 1.2rem;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.drawer__tab:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.drawer__tab.is-active {
+  border-color: currentColor;
+}
+
+.drawer__tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.4rem;
+  font-size: 0.85em;
+  background: rgba(0, 0, 0, 0.08);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+}
+
+.drawer__panels {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.drawer__panel {
+  display: none;
+}
+
+.drawer__panel.is-active {
+  display: block;
+}
+
+.cart-drawer__wishlist {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.cart-drawer__wishlist-empty,
+.cart-drawer__wishlist-loading {
+  text-align: center;
+  margin: 2.4rem 0;
+  color: rgba(var(--color-foreground), 0.7);
+}
+
+.cart-drawer__wishlist-item {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 1.2rem;
+  align-items: start;
+}
+
+.cart-drawer__wishlist-media {
+  position: relative;
+  min-height: 96px;
+}
+
+.cart-drawer__wishlist-image {
+  width: 100%;
+  border-radius: 8px;
+  object-fit: cover;
+}
+
+.cart-drawer__wishlist-remove {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(40%, -40%);
+}
+
+.cart-drawer__wishlist-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.cart-drawer__wishlist-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: inherit;
+  text-decoration: none;
+}
+
+.cart-drawer__wishlist-price {
+  font-weight: 600;
+}
+
+.cart-drawer__wishlist-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.cart-drawer__wishlist-sizes {
+  display: none;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.cart-drawer__wishlist-sizes.is-open {
+  display: flex;
+}
+
+.cart-drawer__wishlist-size-label {
+  font-size: 1.3rem;
+  color: rgba(var(--color-foreground), 0.7);
+}
+
+.cart-drawer__wishlist-size-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.cart-drawer__wishlist-size-button {
+  min-width: 48px;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--color-foreground), 0.2);
+  background: transparent;
+  cursor: pointer;
+  font-size: 1.3rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.cart-drawer__wishlist-size-button:hover,
+.cart-drawer__wishlist-size-button:focus-visible {
+  border-color: rgba(var(--color-foreground), 0.4);
+  background: rgba(var(--color-foreground), 0.06);
+  outline: none;
+}
+
+.cart-drawer__wishlist-size-button.is-loading {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.cart-drawer__wishlist-error {
+  color: #d23f57;
+  font-size: 1.3rem;
+}
+
 .cart-drawer__collection {
   margin: 0 2.5rem 1.5rem;
 }

--- a/assets/wishlist.css
+++ b/assets/wishlist.css
@@ -1,4 +1,4 @@
-.il-wishlist-overlay{position:absolute;top:8px;left:8px;z-index:3}
+.il-wishlist-overlay{position:absolute;top:12px;right:12px;z-index:3}
 .il-wishlist-btn{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border:none;border-radius:999px;background:rgba(255,255,255,.9);color:#d23f57;cursor:pointer;padding:0;transition:transform .12s,background .12s}
 .il-wishlist-btn:hover{transform:scale(1.04)}
 .il-heart{width:22px;height:22px}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -329,6 +329,7 @@ menu-drawer > details[open] > summary::before {
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
     {{ 'filters_cheyenne.css' | asset_url | stylesheet_tag }}
+    {{ 'wishlist.css' | asset_url | stylesheet_tag }}
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}
@@ -462,5 +463,6 @@ menu-drawer > details[open] > summary::before {
     {%- if settings.cart_type == 'drawer' -%}
       <script src="{{ 'cart-drawer.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
+    <script src="{{ 'wishlist.js' | asset_url }}" defer="defer"></script>
   </body>
 </html>

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -36,6 +36,7 @@
     overflow: hidden;
     pointer-events: auto; /* Ensure pointer events are allowed */
     touch-action: auto; /* Let the browser decide (default behavior) */
+    position: relative;
   }
   .swiper-wrapper {
     display: flex;
@@ -181,6 +182,9 @@
       >
        {% if card_product.featured_media %}
   <div class="card__media swiper-container">
+    <div class="il-wishlist-overlay">
+      {% render 'wishlist-heart', product: card_product %}
+    </div>
     <div class="swiper-wrapper">
       {% for media in card_product.media %}
         {% if media.preview_image != blank %}

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -27,44 +27,6 @@
       aria-label="{{ 'sections.cart.title' | t }}"
       tabindex="-1"
     >
-      {%- if cart == empty -%}
-        <div class="drawer__inner-empty">
-          <div class="cart-drawer__warnings center{% if settings.cart_drawer_collection != blank %} cart-drawer__warnings--has-collection{% endif %}">
-            <div class="cart-drawer__empty-content">
-              <h2 class="cart__empty-text">{{ 'sections.cart.empty' | t }}</h2>
-              <button
-                class="drawer__close"
-                type="button"
-                onclick="this.closest('cart-drawer').close()"
-                aria-label="{{ 'accessibility.close' | t }}"
-              >
-                <span class="svg-wrapper">
-                  {{- 'icon-close.svg' | inline_asset_content -}}
-                </span>
-              </button>
-              <a
-                href="#"
-                class="button"
-                onclick="event.preventDefault(); const drawer=document.querySelector('header-drawer'); const details=drawer?.querySelector('details'); if(details&&!details.hasAttribute('open')) drawer.querySelector('summary')?.click(); document.querySelector('cart-drawer')?.close();"
-              >
-                {{ 'general.continue_shopping' | t }}
-              </a>
-
-              {%- if shop.customer_accounts_enabled and customer == null -%}
-                <p class="cart__login-title h3">{{ 'sections.cart.login.title' | t }}</p>
-                <p class="cart__login-paragraph">
-                  {{ 'sections.cart.login.paragraph_html' | t: link: routes.account_login_url }}
-                </p>
-              {%- endif -%}
-            </div>
-          </div>
-          {%- if settings.cart_drawer_collection != blank -%}
-            <div class="cart-drawer__collection">
-              {% render 'card-collection', card_collection: settings.cart_drawer_collection, columns: 1 %}
-            </div>
-          {%- endif -%}
-        </div>
-      {%- endif -%}
       <div class="drawer__header">
         <h2 class="drawer__heading">{{ 'sections.cart.title' | t }}</h2>
         <button
@@ -78,6 +40,67 @@
           </span>
         </button>
       </div>
+      <div class="drawer__tabs" role="tablist">
+        <button
+          type="button"
+          class="drawer__tab is-active"
+          data-tab-target="cart"
+          aria-controls="CartDrawer-PanelCart"
+          aria-selected="true"
+        >
+          {{ 'sections.cart.title' | t }}
+        </button>
+        <button
+          type="button"
+          class="drawer__tab"
+          data-tab-target="wishlist"
+          aria-controls="CartDrawer-PanelWishlist"
+          aria-selected="false"
+        >
+          Wishlist
+          <span class="drawer__tab-count" data-wishlist-count>0</span>
+        </button>
+      </div>
+      <div class="drawer__panels">
+        <div id="CartDrawer-PanelCart" class="drawer__panel is-active" data-tab-panel="cart">
+          {%- if cart == empty -%}
+            <div class="drawer__inner-empty">
+              <div class="cart-drawer__warnings center{% if settings.cart_drawer_collection != blank %} cart-drawer__warnings--has-collection{% endif %}">
+                <div class="cart-drawer__empty-content">
+                  <h2 class="cart__empty-text">{{ 'sections.cart.empty' | t }}</h2>
+                  <button
+                    class="drawer__close"
+                    type="button"
+                    onclick="this.closest('cart-drawer').close()"
+                    aria-label="{{ 'accessibility.close' | t }}"
+                  >
+                    <span class="svg-wrapper">
+                      {{- 'icon-close.svg' | inline_asset_content -}}
+                    </span>
+                  </button>
+                  <a
+                    href="#"
+                    class="button"
+                    onclick="event.preventDefault(); const drawer=document.querySelector('header-drawer'); const details=drawer?.querySelector('details'); if(details&&!details.hasAttribute('open')) drawer.querySelector('summary')?.click(); document.querySelector('cart-drawer')?.close();"
+                  >
+                    {{ 'general.continue_shopping' | t }}
+                  </a>
+
+                  {%- if shop.customer_accounts_enabled and customer == null -%}
+                    <p class="cart__login-title h3">{{ 'sections.cart.login.title' | t }}</p>
+                    <p class="cart__login-paragraph">
+                      {{ 'sections.cart.login.paragraph_html' | t: link: routes.account_login_url }}
+                    </p>
+                  {%- endif -%}
+                </div>
+              </div>
+              {%- if settings.cart_drawer_collection != blank -%}
+                <div class="cart-drawer__collection">
+                  {% render 'card-collection', card_collection: settings.cart_drawer_collection, columns: 1 %}
+                </div>
+              {%- endif -%}
+            </div>
+          {%- endif -%}
       <cart-drawer-items
         {% if cart == empty %}
           class=" is-empty"
@@ -558,6 +581,13 @@
           >
             {{ 'sections.cart.checkout' | t }}
           </button>
+        </div>
+      </div>
+        </div>
+        <div id="CartDrawer-PanelWishlist" class="drawer__panel" data-tab-panel="wishlist">
+          <div class="cart-drawer__wishlist" data-wishlist-container>
+            <p class="cart-drawer__wishlist-empty">Your wishlist is empty.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/snippets/wishlist-heart.liquid
+++ b/snippets/wishlist-heart.liquid
@@ -3,6 +3,8 @@
 {%- assign handle = product.handle -%}
 {%- assign title = product.title | escape -%}
 {%- assign image = product.featured_image | img_url: '360x' -%}
+{%- assign url = product.url -%}
+{%- assign price = product.price | money | escape -%}
 
 <button
   class="il-wishlist-btn"
@@ -13,6 +15,8 @@
   data-handle="{{ handle }}"
   data-title="{{ title }}"
   data-image="{{ image }}"
+  data-url="{{ url }}"
+  data-price="{{ price }}"
 >
   <svg class="il-heart" viewBox="0 0 24 24" aria-hidden="true">
     <path class="il-heart-outline"


### PR DESCRIPTION
## Summary
- add a cart drawer wishlist tab fed from local-storage backed wishlist data
- implement tab handling, wishlist rendering, and add-to-cart with size selection inside the drawer
- surface wishlist hearts on product cards and load supporting assets/theme styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca91f94aa48325a13bb29aa4983590