### PR TITLE
Add wishlist drawer tab and product heart toggle

### DIFF
--- a/assets/wishlist.css
+++ b/assets/wishlist.css
@@ -1,15 +1,190 @@
-.il-wishlist-overlay{position:absolute;top:8px;left:8px;z-index:3}
-.il-wishlist-btn{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;border:none;border-radius:999px;background:rgba(255,255,255,.9);color:#d23f57;cursor:pointer;padding:0;transition:transform .12s,background .12s}
-.il-wishlist-btn:hover{transform:scale(1.04)}
-.il-heart{width:22px;height:22px}
-.il-heart-fill{opacity:0;transition:opacity .14s}
-.il-wishlist-btn.is-active .il-heart-fill{opacity:1}
-.il-wishlist-btn.is-active .il-heart-outline{opacity:0}
+.wishlist-toggle {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(var(--color-foreground, 18, 18, 18), 0.08);
+  background: rgba(var(--color-background, 255, 255, 255), 0.9);
+  color: rgb(var(--color-foreground, 18, 18, 18));
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
 
-.il-wishlist-modal[hidden]{display:none!important}
-.il-wishlist-modal__backdrop{position:fixed;inset:0;background:rgba(0,0,0,.45)}
-.il-wishlist-modal__dialog{position:fixed;inset:0;margin:auto;width:92%;max-width:420px;background:#fff;border-radius:12px;padding:20px;box-shadow:0 12px 30px rgba(0,0,0,.2)}
-.il-wishlist-modal__close{position:absolute;top:8px;right:12px;font-size:24px;border:0;background:transparent;cursor:pointer}
-.il-wishlist-modal__title{margin:6px 0 8px;font-size:1.25rem}
-.il-wishlist-modal__text{color:#444;margin-bottom:16px}
-.il-wishlist-modal__actions{display:flex;gap:8px}
+.wishlist-toggle:hover {
+  transform: scale(1.04);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.wishlist-toggle.is-active {
+  color: var(--wishlist-accent, #d23f57);
+}
+
+.wishlist-toggle__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: block;
+}
+
+.wishlist-toggle__icon path {
+  fill: transparent;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  transition: fill 0.15s ease;
+}
+
+.wishlist-toggle.is-active .wishlist-toggle__icon path {
+  fill: currentColor;
+}
+
+.card__media,
+.card__inner,
+.product-card-wrapper {
+  position: relative;
+}
+
+.drawer__tabs {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.drawer__tab {
+  flex: 1;
+  background: transparent;
+  border: 1px solid rgba(var(--color-foreground, 18, 18, 18), 0.15);
+  border-radius: 999px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(var(--color-foreground, 18, 18, 18), 0.7);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.drawer__tab:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.drawer__tab.is-active {
+  background: rgb(var(--color-foreground, 18, 18, 18));
+  color: rgb(var(--color-background, 255, 255, 255));
+  border-color: rgb(var(--color-foreground, 18, 18, 18));
+}
+
+.drawer__panels {
+  margin-top: 1.5rem;
+}
+
+.drawer__panel {
+  display: block;
+}
+
+.drawer__panel:not(.drawer__panel--active) {
+  display: none;
+}
+
+.drawer__wishlist {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 200px;
+}
+
+.drawer__wishlist.is-empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.wishlist-empty {
+  text-align: center;
+  color: rgba(var(--color-foreground, 18, 18, 18), 0.7);
+  margin: 2rem 0;
+}
+
+.wishlist-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.wishlist-item td {
+  vertical-align: top;
+  padding-bottom: 1.25rem;
+}
+
+.wishlist-item__remove {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+}
+
+.wishlist-item__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.wishlist-item__size-selector {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.wishlist-item__size-control {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.wishlist-item__size-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(var(--color-foreground, 18, 18, 18), 0.6);
+}
+
+.wishlist-item__size-selector select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(var(--color-foreground, 18, 18, 18), 0.2);
+  background: transparent;
+  color: rgb(var(--color-foreground, 18, 18, 18));
+}
+
+.wishlist-item__size-selector[hidden] {
+  display: none;
+}
+
+.wishlist-item__sold-out {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: rgba(var(--color-foreground, 18, 18, 18), 0.7);
+}
+
+@media (max-width: 749px) {
+  .drawer__tab {
+    font-size: 0.75rem;
+    padding: 0.5rem 0.5rem;
+  }
+
+  .wishlist-toggle {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+
+  .wishlist-item td {
+    padding-bottom: 1rem;
+  }
+}

--- a/assets/wishlist.js
+++ b/assets/wishlist.js
@@ -1,105 +1,525 @@
 (() => {
-  // Using App Proxy: same-origin calls to /apps/wishlist (Shopify forwards to your server /proxy/wishlist)
-  const apiBase = "/apps/wishlist";
+  const STORAGE_KEY = 'theme-wishlist-cache';
+  const HEART_SELECTOR = '.wishlist-toggle';
+  const DRAWER_SELECTOR = 'cart-drawer';
+  const WISHLIST_CONTAINER_SELECTOR = '[data-wishlist-container]';
+  const TAB_CART = 'cart';
+  const TAB_WISHLIST = 'wishlist';
 
-  // UI helpers
-  const qsa = (s, r=document) => Array.from(r.querySelectorAll(s));
-  const setActive = (btn, active) => {
-    btn.classList.toggle("is-active", !!active);
-    btn.setAttribute("aria-pressed", active ? "true" : "false");
-    btn.setAttribute("aria-label", active ? "Remove from wishlist" : "Add to wishlist");
+  let cachedWishlist = null;
+  const htmlDecoder = document.createElement('textarea');
+
+  const decodeHtml = (value) => {
+    if (typeof value !== 'string') return '';
+    htmlDecoder.innerHTML = value;
+    return htmlDecoder.value;
   };
-  const btnPayload = (btn) => ({
-    product_id: btn.dataset.productId,
-    variant_id: btn.dataset.variantId || "",
-    handle: btn.dataset.handle || "",
-    title: btn.dataset.title || "",
-    image: btn.dataset.image || ""
-  });
 
-  // Modal (login prompt)
-  function openModal(){
-    const m = document.getElementById("il-wishlist-modal"); if(!m) return;
-    m.hidden = false;
-    m.querySelectorAll("[data-il-close]").forEach(b => b.addEventListener("click", closeModal, { once:true }));
-    document.addEventListener("keydown", escClose, { once:true });
-  }
-  function closeModal(){
-    const m = document.getElementById("il-wishlist-modal"); if(!m) return;
-    m.hidden = true; document.removeEventListener("keydown", escClose);
-  }
-  function escClose(e){ if(e.key === "Escape") closeModal(); }
-
-  // API calls via App Proxy
-  async function fetchWishlist(){
-    const res = await fetch(`${apiBase}`, { method: "GET", credentials: "same-origin" });
-    if (res.status === 401) return { loggedIn:false, items:[] };
-    if (!res.ok) return { loggedIn:true, items:[] };
-    const data = await res.json();
-    return { loggedIn:true, items: data.items || [] };
-  }
-  async function addToWishlist(payload){
-    const res = await fetch(`${apiBase}`, {
-      method:"POST",
-      headers:{"Content-Type":"application/json"},
-      credentials:"same-origin",
-      body: JSON.stringify(payload)
-    });
-    if (res.status === 401) return { ok:false, auth:false };
-    return { ok:res.ok, auth:true };
-  }
-  async function removeFromWishlist(product_id, variant_id=""){
-    const url = new URL(apiBase, window.location.origin);
-    url.searchParams.set("product_id", product_id);
-    if (variant_id) url.searchParams.set("variant_id", variant_id);
-    const res = await fetch(url.toString(), { method:"DELETE", credentials:"same-origin" });
-    if (res.status === 401) return { ok:false, auth:false };
-    return { ok:res.ok, auth:true };
-  }
-
-  async function syncStateFromServer(){
-    const { loggedIn, items } = await fetchWishlist();
-    if (!loggedIn) return; // leave all hearts empty
-    const set = new Set(items.map(i => String(i.product_id) + "::" + (i.variant_id || "")));
-    qsa(".il-wishlist-btn").forEach(btn => {
-      const key = String(btn.dataset.productId) + "::" + (btn.dataset.variantId || "");
-      setActive(btn, set.has(key));
-    });
-  }
-
-  async function onClickHeart(e){
-    const btn = e.currentTarget;
-    const active = btn.classList.contains("is-active");
-    const { product_id, variant_id } = btnPayload(btn);
-
-    // Optimistic UI
-    setActive(btn, !active);
-
-    const outcome = active
-      ? await removeFromWishlist(product_id, variant_id)
-      : await addToWishlist(btnPayload(btn));
-
-    if (!outcome.ok) {
-      setActive(btn, active); // revert
-      if (outcome.auth === false) openModal();
+  const parseJSONAttribute = (value, fallback) => {
+    if (!value) return fallback;
+    try {
+      return JSON.parse(decodeHtml(value));
+    } catch (error) {
+      console.warn('Failed to parse JSON attribute', error);
+      return fallback;
     }
-  }
+  };
 
-  function initHearts(){
-    qsa(".il-wishlist-btn").forEach(btn => {
-      if (btn.dataset.init) return;
-      btn.dataset.init = "1";
-      btn.addEventListener("click", onClickHeart, { passive:true });
-      setActive(btn, false);
+  const escapeHtml = (value) => {
+    if (value == null) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+
+  const loadWishlist = () => {
+    if (cachedWishlist) return cachedWishlist.slice();
+
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        cachedWishlist = [];
+        return [];
+      }
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        cachedWishlist = parsed;
+        return parsed.slice();
+      }
+    } catch (error) {
+      console.warn('Unable to read wishlist from storage', error);
+    }
+
+    cachedWishlist = [];
+    return [];
+  };
+
+  const saveWishlist = (items) => {
+    cachedWishlist = items.slice();
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(cachedWishlist));
+    } catch (error) {
+      console.warn('Unable to persist wishlist', error);
+    }
+    renderWishlist();
+    syncHearts();
+  };
+
+  const findWishlistItem = (handle) => loadWishlist().find((item) => item.handle === handle);
+
+  const addToWishlist = (product) => {
+    if (!product?.handle) return;
+    const wishlist = loadWishlist();
+    const existingIndex = wishlist.findIndex((item) => item.handle === product.handle);
+    if (existingIndex >= 0) {
+      wishlist[existingIndex] = product;
+      saveWishlist(wishlist);
+      return;
+    }
+    wishlist.push(product);
+    saveWishlist(wishlist);
+  };
+
+  const removeFromWishlist = (handle) => {
+    if (!handle) return;
+    const wishlist = loadWishlist().filter((item) => item.handle !== handle);
+    saveWishlist(wishlist);
+  };
+
+  const getCardFromHeart = (button) => button?.closest('.product-card-wrapper');
+
+  const getProductFromCard = (card) => {
+    if (!card) return null;
+    const handle = card.dataset.productHandle;
+    if (!handle) return null;
+
+    const variants = parseJSONAttribute(card.dataset.variants, []);
+    const sizeIndex = Number.parseInt(card.dataset.sizeIndex, 10);
+
+    return {
+      handle,
+      title: card.dataset.productTitle || '',
+      url: card.dataset.productUrl || '',
+      image: card.dataset.productImage || '',
+      price: card.dataset.productPrice || '',
+      sizeIndex: Number.isNaN(sizeIndex) ? -1 : sizeIndex,
+      variants: variants.map((variant) => ({
+        id: variant.id,
+        title: variant.title,
+        available: variant.available,
+        options: variant.options,
+        price: variant.price,
+      })),
+    };
+  };
+
+  const handleHeartClick = (event) => {
+    event.preventDefault();
+    const button = event.currentTarget;
+    const card = getCardFromHeart(button);
+    const product = getProductFromCard(card);
+    if (!product) return;
+
+    const exists = !!findWishlistItem(product.handle);
+    if (exists) {
+      removeFromWishlist(product.handle);
+    } else {
+      addToWishlist(product);
+    }
+  };
+
+  const attachHeartListeners = (root = document) => {
+    root.querySelectorAll(HEART_SELECTOR).forEach((button) => {
+      if (button.dataset.wishlistBound) return;
+      button.dataset.wishlistBound = 'true';
+      button.addEventListener('click', handleHeartClick);
     });
+  };
+
+  const syncHearts = () => {
+    const handles = new Set(loadWishlist().map((item) => item.handle));
+    document.querySelectorAll(HEART_SELECTOR).forEach((button) => {
+      const card = getCardFromHeart(button);
+      const handle = card?.dataset.productHandle;
+      const active = handle ? handles.has(handle) : false;
+      button.classList.toggle('is-active', active);
+      button.setAttribute('aria-pressed', active ? 'true' : 'false');
+      button.setAttribute('aria-label', active ? window.wishlistStrings?.remove || 'Remove from wishlist' : window.wishlistStrings?.add || 'Add to wishlist');
+    });
+  };
+
+  const getDrawer = () => document.querySelector(DRAWER_SELECTOR);
+
+  const updateDrawerHeading = (drawer, tab) => {
+    const heading = drawer?.querySelector('.drawer__heading');
+    if (!heading) return;
+    if (!heading.dataset.cartTitle) {
+      heading.dataset.cartTitle = heading.textContent.trim();
+    }
+    if (!heading.dataset.wishlistTitle) {
+      heading.dataset.wishlistTitle = heading.dataset.wishlist || 'Wishlist';
+    }
+    const text = tab === TAB_WISHLIST ? heading.dataset.wishlistTitle : heading.dataset.cartTitle;
+    heading.textContent = text;
+  };
+
+  const setActiveDrawerTab = (tab) => {
+    const drawer = getDrawer();
+    if (!drawer) return;
+
+    const tabs = drawer.querySelectorAll('[data-tab-target]');
+    const panels = drawer.querySelectorAll('[data-tab-panel]');
+
+    tabs.forEach((button) => {
+      const isActive = button.dataset.tabTarget === tab;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    });
+
+    panels.forEach((panel) => {
+      const isActive = panel.dataset.tabPanel === tab;
+      panel.classList.toggle('drawer__panel--active', isActive);
+      panel.toggleAttribute('hidden', !isActive);
+    });
+
+    updateDrawerHeading(drawer, tab);
+  };
+
+  const initDrawerTabs = () => {
+    const drawer = getDrawer();
+    if (!drawer) return;
+
+    const tabs = drawer.querySelectorAll('[data-tab-target]');
+    tabs.forEach((tab) => {
+      if (tab.dataset.wishlistBound) return;
+      tab.dataset.wishlistBound = 'true';
+      tab.addEventListener('click', () => setActiveDrawerTab(tab.dataset.tabTarget));
+    });
+
+    const activeTabButton = Array.from(tabs).find((tab) => tab.classList.contains('is-active'));
+    setActiveDrawerTab(activeTabButton?.dataset.tabTarget || TAB_CART);
+  };
+
+  const getAvailableVariants = (item) => item.variants.filter((variant) => variant.available);
+
+  const createWishlistRowMarkup = (item) => {
+    const imageMarkup = item.image
+      ? `<img src="${escapeHtml(item.image)}" alt="${escapeHtml(item.title)}" loading="lazy">`
+      : `<div class="wishlist-item__placeholder" aria-hidden="true"></div>`;
+
+    const priceMarkup = item.price
+      ? `<span class="price price--end">${escapeHtml(item.price)}</span>`
+      : '';
+
+    const availableVariants = getAvailableVariants(item);
+    const sizeSelectorId = `WishlistSize-${escapeHtml(item.handle)}`;
+
+    let sizeSelectorMarkup = '';
+    if (item.sizeIndex >= 0) {
+      if (availableVariants.length) {
+        const options = availableVariants
+          .map((variant) => {
+            const label = variant.options?.[item.sizeIndex] || variant.title;
+            return `<option value="${variant.id}">${escapeHtml(label)}</option>`;
+          })
+          .join('');
+        sizeSelectorMarkup = `
+          <div class="wishlist-item__size-selector" data-size-selector hidden>
+            <label class="wishlist-item__size-label" for="${sizeSelectorId}">${escapeHtml(window.wishlistStrings?.sizeLabel || 'Select a size')}</label>
+            <div class="wishlist-item__size-control">
+              <select id="${sizeSelectorId}" data-size-select>
+                ${options}
+              </select>
+              <button type="button" class="button button--primary wishlist-item__confirm" data-wishlist-confirm>
+                ${escapeHtml(window.wishlistStrings?.confirm || 'Add')}
+              </button>
+            </div>
+          </div>`;
+      } else {
+        sizeSelectorMarkup = `<p class="wishlist-item__sold-out">${escapeHtml(window.wishlistStrings?.soldOut || 'Sold out')}</p>`;
+      }
+    }
+
+    const hasAvailableVariant = availableVariants.length > 0;
+
+    return `
+      <td class="cart-item__media">
+        <a href="${escapeHtml(item.url)}" class="cart-item__link" tabindex="-1" aria-hidden="true"></a>
+        ${imageMarkup}
+      </td>
+      <td class="cart-item__details">
+        <a href="${escapeHtml(item.url)}" class="cart-item__name h4 break">${escapeHtml(item.title)}</a>
+        <button type="button" class="link wishlist-item__remove" data-wishlist-remove>
+          ${escapeHtml(window.wishlistStrings?.remove || 'Remove')}
+        </button>
+      </td>
+      <td class="cart-item__totals right">
+        <div class="cart-item__price-wrapper">
+          ${priceMarkup}
+        </div>
+      </td>
+      <td class="cart-item__actions">
+        <button type="button" class="button button--tertiary wishlist-item__add" data-wishlist-add ${hasAvailableVariant ? '' : 'disabled'}>
+          ${escapeHtml(window.wishlistStrings?.addToCart || 'Add to cart')}
+        </button>
+        ${sizeSelectorMarkup}
+      </td>`;
+  };
+
+  const renderWishlist = () => {
+    const containers = document.querySelectorAll(WISHLIST_CONTAINER_SELECTOR);
+    if (!containers.length) return;
+    const items = loadWishlist();
+
+    containers.forEach((container) => {
+      const table = container.querySelector('[data-wishlist-table]');
+      const list = container.querySelector('[data-wishlist-items]');
+      const emptyState = container.querySelector('[data-wishlist-empty]');
+      if (!list || !table || !emptyState) return;
+
+      list.innerHTML = '';
+
+      if (!items.length) {
+        container.classList.add('is-empty');
+        table.hidden = true;
+        emptyState.hidden = false;
+        return;
+      }
+
+      container.classList.remove('is-empty');
+      table.hidden = false;
+      emptyState.hidden = true;
+
+      items.forEach((item) => {
+        const row = document.createElement('tr');
+        row.className = 'cart-item wishlist-item';
+        row.dataset.wishlistItem = 'true';
+        row.dataset.handle = item.handle;
+        row.wishlistItem = item;
+        row.innerHTML = createWishlistRowMarkup(item);
+        list.appendChild(row);
+      });
+    });
+  };
+
+  const getVariantForDirectAdd = (item) => {
+    const available = getAvailableVariants(item);
+    if (available.length) return available[0];
+    return item.variants[0];
+  };
+
+  const refreshCartDrawer = () => {
+    if (!window.routes?.cart_url) return Promise.resolve();
+    return fetch(`${window.routes.cart_url}?section_id=cart-drawer`)
+      .then((response) => response.text())
+      .then((responseText) => {
+        const parser = new DOMParser();
+        const html = parser.parseFromString(responseText, 'text/html');
+        const selectors = ['cart-drawer-items', '.cart-drawer__footer'];
+        selectors.forEach((selector) => {
+          const target = document.querySelector(selector);
+          const source = html.querySelector(selector);
+          if (target && source) {
+            target.replaceWith(source);
+          }
+        });
+        const drawer = getDrawer();
+        if (drawer) {
+          drawer.classList.remove('is-empty');
+          if (!drawer.classList.contains('active')) {
+            drawer.open();
+          }
+        }
+        if (typeof publish === 'function') {
+          publish(PUB_SUB_EVENTS.cartUpdate, { source: 'wishlist' });
+        }
+      })
+      .catch((error) => console.error('Failed to refresh cart drawer', error));
+  };
+
+  const addVariantToCart = (variantId, row) => {
+    if (!variantId || !window.routes?.cart_add_url) return;
+    const addButton = row?.querySelector('[data-wishlist-add]');
+    if (addButton) addButton.disabled = true;
+
+    const body = JSON.stringify({
+      items: [{ id: variantId, quantity: 1 }],
+      sections: ['cart-drawer', 'cart-icon-bubble'],
+      sections_url: window.location.pathname,
+    });
+
+    fetch(`${window.routes.cart_add_url}`, { ...fetchConfig(), body })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.status && data.status !== 200) {
+          throw new Error(data.description || 'Unable to add to cart');
+        }
+      })
+      .then(() => refreshCartDrawer())
+      .then(() => setActiveDrawerTab(TAB_CART))
+      .catch((error) => {
+        console.error(error);
+      })
+      .finally(() => {
+        if (addButton) addButton.disabled = false;
+        const selector = row?.querySelector('[data-size-selector]');
+        if (selector) selector.hidden = true;
+      });
+  };
+
+  const handleRemoveClick = (button) => {
+    const row = button.closest('[data-wishlist-item]');
+    if (!row) return;
+    removeFromWishlist(row.dataset.handle);
+  };
+
+  const handleAddClick = (button) => {
+    const row = button.closest('[data-wishlist-item]');
+    if (!row) return;
+    const item = row.wishlistItem || findWishlistItem(row.dataset.handle);
+    if (!item) return;
+
+    const availableVariants = getAvailableVariants(item);
+    if (!availableVariants.length) return;
+
+    if (item.sizeIndex >= 0) {
+      const selector = row.querySelector('[data-size-selector]');
+      if (selector) {
+        selector.hidden = !selector.hidden;
+        if (!selector.hidden) {
+          const select = selector.querySelector('[data-size-select]');
+          select?.focus();
+        }
+      }
+      return;
+    }
+
+    const variant = getVariantForDirectAdd(item);
+    addVariantToCart(variant?.id, row);
+  };
+
+  const handleConfirmClick = (button) => {
+    const row = button.closest('[data-wishlist-item]');
+    if (!row) return;
+    const item = row.wishlistItem || findWishlistItem(row.dataset.handle);
+    if (!item) return;
+
+    const select = row.querySelector('[data-size-select]');
+    const variantId = select?.value;
+    if (!variantId) return;
+    addVariantToCart(variantId, row);
+  };
+
+  const handleWishlistClicks = (event) => {
+    const removeButton = event.target.closest('[data-wishlist-remove]');
+    if (removeButton) {
+      event.preventDefault();
+      handleRemoveClick(removeButton);
+      return;
+    }
+
+    const confirmButton = event.target.closest('[data-wishlist-confirm]');
+    if (confirmButton) {
+      event.preventDefault();
+      handleConfirmClick(confirmButton);
+      return;
+    }
+
+    const addButton = event.target.closest('[data-wishlist-add]');
+    if (addButton) {
+      event.preventDefault();
+      handleAddClick(addButton);
+    }
+  };
+
+  const registerWishlistContainerListeners = () => {
+    document.addEventListener('click', handleWishlistClicks);
+  };
+
+  const onSectionLoad = (event) => {
+    const container = event.target || event.detail?.target;
+    if (!(container instanceof HTMLElement)) return;
+    if (container.querySelector?.(WISHLIST_CONTAINER_SELECTOR) || container.matches?.(WISHLIST_CONTAINER_SELECTOR)) {
+      renderWishlist();
+    }
+    if (container.querySelector?.(HEART_SELECTOR) || container.matches?.(HEART_SELECTOR)) {
+      attachHeartListeners(container);
+      syncHearts();
+    }
+    if (container.querySelector?.(DRAWER_SELECTOR) || container.matches?.(DRAWER_SELECTOR)) {
+      initDrawerTabs();
+    }
+  };
+
+  const observeDomMutations = () => {
+    const observer = new MutationObserver((mutations) => {
+      let heartsUpdated = false;
+      let wishlistUpdated = false;
+      let tabsUpdated = false;
+
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (!(node instanceof HTMLElement)) return;
+          if (node.matches?.(HEART_SELECTOR) || node.querySelector?.(HEART_SELECTOR)) {
+            heartsUpdated = true;
+          }
+          if (node.matches?.(WISHLIST_CONTAINER_SELECTOR) || node.querySelector?.(WISHLIST_CONTAINER_SELECTOR)) {
+            wishlistUpdated = true;
+          }
+          if (
+            node.matches?.(DRAWER_SELECTOR) ||
+            node.querySelector?.(DRAWER_SELECTOR) ||
+            node.matches?.('[data-tab-target]') ||
+            node.querySelector?.('[data-tab-target]')
+          ) {
+            tabsUpdated = true;
+          }
+        });
+      });
+
+      if (heartsUpdated) {
+        attachHeartListeners();
+        syncHearts();
+      }
+      if (wishlistUpdated) {
+        renderWishlist();
+      }
+      if (tabsUpdated) {
+        initDrawerTabs();
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+  };
+
+  const init = () => {
+    window.wishlistStrings = {
+      add: 'Add to wishlist',
+      remove: 'Remove from wishlist',
+      addToCart: 'Add to cart',
+      confirm: 'Add',
+      sizeLabel: 'Select a size',
+      soldOut: 'Sold out',
+      wishlist: 'Wishlist',
+      ...window.wishlistStrings,
+    };
+
+    attachHeartListeners();
+    syncHearts();
+    renderWishlist();
+    initDrawerTabs();
+    registerWishlistContainerListeners();
+
+    document.addEventListener('shopify:section:load', onSectionLoad);
+    observeDomMutations();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
   }
-
-  // Handle dynamic sections / SPA-like theme updates
-  const observer = new MutationObserver(() => initHearts());
-  observer.observe(document.documentElement, { childList:true, subtree:true });
-
-  document.addEventListener("DOMContentLoaded", async () => {
-    initHearts();
-    await syncStateFromServer();
-  });
 })();

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -80,6 +80,7 @@
     <script src="{{ 'details-disclosure.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'details-modal.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'search-form.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'wishlist.js' | asset_url }}" defer="defer"></script>
     
 
     {%- if settings.animations_reveal_on_scroll -%}
@@ -329,6 +330,7 @@ menu-drawer > details[open] > summary::before {
 
     {{ 'base.css' | asset_url | stylesheet_tag }}
     {{ 'filters_cheyenne.css' | asset_url | stylesheet_tag }}
+    {{ 'wishlist.css' | asset_url | stylesheet_tag }}
     <link rel="stylesheet" href="{{ 'component-cart-items.css' | asset_url }}" media="print" onload="this.media='all'">
 
     {%- if settings.cart_type == 'drawer' -%}

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -162,6 +162,10 @@
     data-variant-inventory='{{ variant_inventory_map | strip_newlines | escape }}'
     data-color-index="{{ color_option_index }}"
     data-size-index="{{ size_option_index }}"
+    data-product-title="{{ card_product.title | escape }}"
+    data-product-url="{{ card_product.url | escape }}"
+    data-product-image="{% if card_product.featured_media %}{{ card_product.featured_media | image_url: width: 360 | escape }}{% endif %}"
+    data-product-price="{{ card_product.price | money_without_trailing_zeros | escape }}"
   >
     <div
       class="
@@ -175,6 +179,16 @@
       "
       style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"
     >
+      <button
+        class="wishlist-toggle"
+        type="button"
+        aria-pressed="false"
+        aria-label="{{ 'general.add_to_wishlist' | t | default: 'Add to wishlist' }}"
+      >
+        <svg class="wishlist-toggle__icon" viewBox="0 0 24 24" role="presentation" focusable="false">
+          <path d="M12 21.35 10.55 20.03C6.2 15.99 3 12.99 3 9.31 3 6.28 5.42 4 8.4 4A5.2 5.2 0 0 1 12 5.86 5.2 5.2 0 0 1 15.6 4C18.58 4 21 6.28 21 9.31c0 3.68-3.2 6.68-7.55 10.72z" />
+        </svg>
+      </button>
       <div
         class="card__inner {% if settings.card_style == 'standard' %}color-{{ settings.card_color_scheme }} gradient{% endif %}{% if card_product.featured_media or settings.card_style == 'standard' %} ratio{% endif %}"
         style="--ratio-percent: {{ 1 | divided_by: ratio | times: 100 }}%;"

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -66,7 +66,7 @@
         </div>
       {%- endif -%}
       <div class="drawer__header">
-        <h2 class="drawer__heading">{{ 'sections.cart.title' | t }}</h2>
+        <h2 class="drawer__heading" data-wishlist="{{ 'general.wishlist' | t | default: 'Wishlist' }}">{{ 'sections.cart.title' | t }}</h2>
         <button
           class="drawer__close"
           type="button"
@@ -78,6 +78,38 @@
           </span>
         </button>
       </div>
+      <div class="drawer__tabs" role="tablist" aria-label="{{ 'sections.cart.title' | t }}">
+        <button
+          type="button"
+          class="drawer__tab is-active"
+          data-tab-target="cart"
+          id="CartDrawerTab-Cart"
+          role="tab"
+          aria-controls="CartDrawer-CartPanel"
+          aria-selected="true"
+        >
+          {{ 'sections.cart.title' | t }}
+        </button>
+        <button
+          type="button"
+          class="drawer__tab"
+          data-tab-target="wishlist"
+          id="CartDrawerTab-Wishlist"
+          role="tab"
+          aria-controls="CartDrawer-WishlistPanel"
+          aria-selected="false"
+        >
+          {{ 'general.wishlist' | t | default: 'Wishlist' }}
+        </button>
+      </div>
+      <div class="drawer__panels">
+        <div
+          class="drawer__panel drawer__panel--active"
+          id="CartDrawer-CartPanel"
+          data-tab-panel="cart"
+          role="tabpanel"
+          aria-labelledby="CartDrawerTab-Cart"
+        >
       <cart-drawer-items
         {% if cart == empty %}
           class=" is-empty"
@@ -561,5 +593,32 @@
         </div>
       </div>
     </div>
+    <div
+      class="drawer__panel"
+      id="CartDrawer-WishlistPanel"
+      data-tab-panel="wishlist"
+      role="tabpanel"
+      aria-labelledby="CartDrawerTab-Wishlist"
+      hidden
+    >
+      <div id="CartDrawer-Wishlist" class="drawer__wishlist is-empty" data-wishlist-container>
+        <table class="cart-items wishlist-table" role="table" data-wishlist-table hidden>
+          <thead class="visually-hidden">
+            <tr>
+              <th scope="col">{{ 'sections.cart.headings.image' | t }}</th>
+              <th scope="col">{{ 'sections.cart.headings.product' | t }}</th>
+              <th scope="col">{{ 'sections.cart.headings.total' | t }}</th>
+              <th scope="col">{{ 'general.actions' | t | default: 'Actions' }}</th>
+            </tr>
+          </thead>
+          <tbody data-wishlist-items></tbody>
+        </table>
+        <div class="wishlist-empty" data-wishlist-empty>
+          <p class="cart__empty-text">{{ 'general.wishlist_empty' | t | default: 'Your wishlist is empty.' }}</p>
+        </div>
+      </div>
+    </div>
   </div>
+</div>
+</div>
 </cart-drawer>


### PR DESCRIPTION
## Summary
- add localStorage-backed wishlist logic with cart drawer synchronization and tab switching
- render wishlist tab in the cart drawer with add-to-cart size selection controls and empty state
- decorate product cards with heart toggles and load supporting assets in the theme layout

## Testing
- `theme check` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca91f94aa48325a13bb29aa4983590