### PR TITLE
Add wishlist heart to product detail layouts

### DIFF
--- a/assets/wishlist.css
+++ b/assets/wishlist.css
@@ -42,6 +42,36 @@
   fill: currentColor;
 }
 
+.product-title-with-wishlist .wishlist-toggle,
+.desktop-product-title-wrapper .wishlist-toggle {
+  position: static;
+  top: auto;
+  right: auto;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  flex-shrink: 0;
+}
+
+.product-title-with-wishlist .wishlist-toggle:hover,
+.desktop-product-title-wrapper .wishlist-toggle:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.product-title-with-wishlist .wishlist-toggle__icon,
+.desktop-product-title-wrapper .wishlist-toggle__icon {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.product-title-with-wishlist .wishlist-toggle__icon path,
+.desktop-product-title-wrapper .wishlist-toggle__icon path {
+  stroke-width: 1.6;
+}
+
 .card__media,
 .card__inner,
 .product-card-wrapper {

--- a/sections/desktop-product.liquid
+++ b/sections/desktop-product.liquid
@@ -275,6 +275,18 @@
     margin-bottom: 0;
   }
 
+  .desktop-product-title-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 8px;
+  }
+
+  .desktop-product-title-wrapper h1 {
+    flex: 1;
+    margin: 0;
+  }
+
   desktop-related-products {
     display: none;
   }
@@ -379,6 +391,24 @@
 
 </style>
 
+{% liquid
+  assign featured_media = product.featured_media | default: product.featured_image
+  if featured_media
+    assign wishlist_image = featured_media | image_url: width: 360
+  else
+    assign wishlist_image = ''
+  endif
+
+  assign size_option_index = -1
+  for option in product.options_with_values
+    assign option_name = option.name | downcase
+    if option_name == 'size' or option_name == 'tamanho'
+      assign size_option_index = forloop.index0
+      break
+    endif
+  endfor
+%}
+
 <div class="desktop-product-section">
   <!-- Left side: Thumbnails + Scrollable Big Images -->
   <div class="desktop-product-media">
@@ -412,9 +442,30 @@
   <!-- Right side: Sticky Info -->
   <div class="desktop-product-info">
     <!-- Title -->
-    <h1>
-      <a class="product__title-link" href="{{ product.url }}">{{ product.title }}</a>
-    </h1>
+    <div
+      class="desktop-product-title-wrapper product-card-wrapper"
+      data-product-handle="{{ product.handle }}"
+      data-product-title="{{ product.title | escape }}"
+      data-product-url="{{ product.url | escape }}"
+      data-product-image="{{ wishlist_image | escape }}"
+      data-product-price="{{ product.price | money_without_trailing_zeros | escape }}"
+      data-variants='{{ product.variants | json | escape }}'
+      data-size-index="{{ size_option_index }}"
+    >
+      <h1>
+        <a class="product__title-link" href="{{ product.url }}">{{ product.title }}</a>
+      </h1>
+      <button
+        class="wishlist-toggle"
+        type="button"
+        aria-pressed="false"
+        aria-label="{{ 'general.add_to_wishlist' | t | default: 'Add to wishlist' }}"
+      >
+        <svg class="wishlist-toggle__icon" viewBox="0 0 24 24" role="presentation" focusable="false">
+          <path d="M12 21.35 10.55 20.03C6.2 15.99 3 12.99 3 9.31 3 6.28 5.42 4 8.4 4A5.2 5.2 0 0 1 12 5.86 5.2 5.2 0 0 1 15.6 4C18.58 4 21 6.28 21 9.31c0 3.68-3.2 6.68-7.55 10.72z" />
+        </svg>
+      </button>
+    </div>
 
     <!-- Price -->
     <div class="price-container">

--- a/sections/sticky-product-bar.liquid
+++ b/sections/sticky-product-bar.liquid
@@ -102,18 +102,25 @@
 #variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--pill {
   margin-inline: 0px!important;
 }
-#sticky-product-bar > div > div > div.sticky-bar-summary > div.product-title {
-    font-family: "Figtree", Arial, Helvetica, sans-serif;
-    font-weight: normal;
-    font-size: 1.6rem;
-    line-height: 2.2rem;
-    text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: black;
-    margin-left: 5%;
-    margin-top: 10px;
+#sticky-product-bar .product-title-with-wishlist {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 10px 5% 0;
+}
+
+#sticky-product-bar .product-title-with-wishlist .product-title {
+  font-family: "Figtree", Arial, Helvetica, sans-serif;
+  font-weight: normal;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: black;
+  margin: 0;
 }
 
 /* Variant picker layout */
@@ -255,6 +262,24 @@
 }
 </style>
 
+{% liquid
+  assign featured_media = product.featured_media | default: product.featured_image
+  if featured_media
+    assign wishlist_image = featured_media | image_url: width: 360
+  else
+    assign wishlist_image = ''
+  endif
+
+  assign size_option_index = -1
+  for option in product.options_with_values
+    assign option_name = option.name | downcase
+    if option_name == 'size' or option_name == 'tamanho'
+      assign size_option_index = forloop.index0
+      break
+    endif
+  endfor
+%}
+
 <!-- Provide the product data in JSON -->
 <script>
   var productData = {{ product | json }};
@@ -265,9 +290,30 @@
   <div class="sticky-bar-inner">
     <div class="sticky-bar-header">
       <!-- Left side: Title, Price, Variant Picker -->
-      <div class="sticky-bar-summary">
-        <div class="product-title">
-          {{ product.title }}
+      <div
+        class="sticky-bar-summary product-card-wrapper"
+        data-product-handle="{{ product.handle }}"
+        data-product-title="{{ product.title | escape }}"
+        data-product-url="{{ product.url | escape }}"
+        data-product-image="{{ wishlist_image | escape }}"
+        data-product-price="{{ product.price | money_without_trailing_zeros | escape }}"
+        data-variants='{{ product.variants | json | escape }}'
+        data-size-index="{{ size_option_index }}"
+      >
+        <div class="product-title-with-wishlist">
+          <div class="product-title">
+            {{ product.title }}
+          </div>
+          <button
+            class="wishlist-toggle"
+            type="button"
+            aria-pressed="false"
+            aria-label="{{ 'general.add_to_wishlist' | t | default: 'Add to wishlist' }}"
+          >
+            <svg class="wishlist-toggle__icon" viewBox="0 0 24 24" role="presentation" focusable="false">
+              <path d="M12 21.35 10.55 20.03C6.2 15.99 3 12.99 3 9.31 3 6.28 5.42 4 8.4 4A5.2 5.2 0 0 1 12 5.86 5.2 5.2 0 0 1 15.6 4C18.58 4 21 6.28 21 9.31c0 3.68-3.2 6.68-7.55 10.72z" />
+            </svg>
+          </button>
         </div>
         <div class="price_variants">
           <div class="product-price">


### PR DESCRIPTION
## Summary
- add wishlist heart controls to desktop and mobile product detail sections
- provide product metadata attributes required for wishlist persistence
- adjust wishlist styling so inline hearts render correctly beside product titles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad41cf01883259c86107862cfe3d6