### PR TITLE
Add wishlist heart to product detail layouts

### DIFF
--- a/assets/wishlist.css
+++ b/assets/wishlist.css
@@ -42,10 +42,67 @@
   fill: currentColor;
 }
 
+.product-title-with-wishlist .wishlist-toggle,
+.desktop-product-title-wrapper .wishlist-toggle {
+  position: static;
+  top: auto;
+  right: auto;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  flex-shrink: 0;
+}
+
+.product-title-with-wishlist .wishlist-toggle:hover,
+.desktop-product-title-wrapper .wishlist-toggle:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.product-title-with-wishlist .wishlist-toggle__icon,
+.desktop-product-title-wrapper .wishlist-toggle__icon {
+  width: 2.25rem;
+  height: 2.25rem;
+}
+
+.product-title-with-wishlist .wishlist-toggle__icon path,
+.desktop-product-title-wrapper .wishlist-toggle__icon path {
+  stroke-width: 1.6;
+}
+
 .card__media,
 .card__inner,
 .product-card-wrapper {
   position: relative;
+}
+
+@media (max-width: 749px) {
+  #sticky-product-bar .sticky-bar-wishlist {
+    position: absolute;
+    top: -3.5rem;
+    right: 1.5rem;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 999px;
+    background: #ffffff;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+  }
+
+  #sticky-product-bar .sticky-bar-wishlist .wishlist-toggle__icon {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+
+  #sticky-product-bar .sticky-bar-wishlist .wishlist-toggle__icon path {
+    stroke-width: 1.6;
+  }
 }
 
 .drawer__tabs {

--- a/sections/desktop-product.liquid
+++ b/sections/desktop-product.liquid
@@ -275,6 +275,18 @@
     margin-bottom: 0;
   }
 
+  .desktop-product-title-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 8px;
+  }
+
+  .desktop-product-title-wrapper h1 {
+    flex: 1;
+    margin: 0;
+  }
+
   desktop-related-products {
     display: none;
   }
@@ -379,6 +391,24 @@
 
 </style>
 
+{% liquid
+  assign featured_media = product.featured_media | default: product.featured_image
+  if featured_media
+    assign wishlist_image = featured_media | image_url: width: 360
+  else
+    assign wishlist_image = ''
+  endif
+
+  assign size_option_index = -1
+  for option in product.options_with_values
+    assign option_name = option.name | downcase
+    if option_name == 'size' or option_name == 'tamanho'
+      assign size_option_index = forloop.index0
+      break
+    endif
+  endfor
+%}
+
 <div class="desktop-product-section">
   <!-- Left side: Thumbnails + Scrollable Big Images -->
   <div class="desktop-product-media">
@@ -412,9 +442,30 @@
   <!-- Right side: Sticky Info -->
   <div class="desktop-product-info">
     <!-- Title -->
-    <h1>
-      <a class="product__title-link" href="{{ product.url }}">{{ product.title }}</a>
-    </h1>
+    <div
+      class="desktop-product-title-wrapper product-card-wrapper"
+      data-product-handle="{{ product.handle }}"
+      data-product-title="{{ product.title | escape }}"
+      data-product-url="{{ product.url | escape }}"
+      data-product-image="{{ wishlist_image | escape }}"
+      data-product-price="{{ product.price | money_without_trailing_zeros | escape }}"
+      data-variants='{{ product.variants | json | escape }}'
+      data-size-index="{{ size_option_index }}"
+    >
+      <h1>
+        <a class="product__title-link" href="{{ product.url }}">{{ product.title }}</a>
+      </h1>
+      <button
+        class="wishlist-toggle"
+        type="button"
+        aria-pressed="false"
+        aria-label="{{ 'general.add_to_wishlist' | t | default: 'Add to wishlist' }}"
+      >
+        <svg class="wishlist-toggle__icon" viewBox="0 0 24 24" role="presentation" focusable="false">
+          <path d="M12 21.35 10.55 20.03C6.2 15.99 3 12.99 3 9.31 3 6.28 5.42 4 8.4 4A5.2 5.2 0 0 1 12 5.86 5.2 5.2 0 0 1 15.6 4C18.58 4 21 6.28 21 9.31c0 3.68-3.2 6.68-7.55 10.72z" />
+        </svg>
+      </button>
+    </div>
 
     <!-- Price -->
     <div class="price-container">

--- a/sections/sticky-product-bar.liquid
+++ b/sections/sticky-product-bar.liquid
@@ -50,7 +50,7 @@
 
 .sticky-bar-inner {
   height: auto;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .drawer-content {
@@ -89,9 +89,9 @@
 
 /* Layout/spacing tweaks */
 #sticky-product-bar > .sticky-bar-inner > div.sticky-bar-summary {
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-top: 3px;
+  position: relative;
+  margin: 10px 5% 0;
+  padding-right: 4.25rem;
 }
 #ProductSubmitButton- {
   margin-top: -7px;
@@ -102,18 +102,17 @@
 #variant-selects-template--24455438926148__sticky_product_bar_HRGKtD > fieldset.js.product-form__input.product-form__input--pill {
   margin-inline: 0px!important;
 }
-#sticky-product-bar > div > div > div.sticky-bar-summary > div.product-title {
-    font-family: "Figtree", Arial, Helvetica, sans-serif;
-    font-weight: normal;
-    font-size: 1.6rem;
-    line-height: 2.2rem;
-    text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: black;
-    margin-left: 5%;
-    margin-top: 10px;
+#sticky-product-bar .sticky-bar-summary .product-title {
+  font-family: "Figtree", Arial, Helvetica, sans-serif;
+  font-weight: normal;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: black;
+  margin: 0;
 }
 
 /* Variant picker layout */
@@ -255,6 +254,24 @@
 }
 </style>
 
+{% liquid
+  assign featured_media = product.featured_media | default: product.featured_image
+  if featured_media
+    assign wishlist_image = featured_media | image_url: width: 360
+  else
+    assign wishlist_image = ''
+  endif
+
+  assign size_option_index = -1
+  for option in product.options_with_values
+    assign option_name = option.name | downcase
+    if option_name == 'size' or option_name == 'tamanho'
+      assign size_option_index = forloop.index0
+      break
+    endif
+  endfor
+%}
+
 <!-- Provide the product data in JSON -->
 <script>
   var productData = {{ product | json }};
@@ -265,7 +282,26 @@
   <div class="sticky-bar-inner">
     <div class="sticky-bar-header">
       <!-- Left side: Title, Price, Variant Picker -->
-      <div class="sticky-bar-summary">
+      <div
+        class="sticky-bar-summary product-card-wrapper"
+        data-product-handle="{{ product.handle }}"
+        data-product-title="{{ product.title | escape }}"
+        data-product-url="{{ product.url | escape }}"
+        data-product-image="{{ wishlist_image | escape }}"
+        data-product-price="{{ product.price | money_without_trailing_zeros | escape }}"
+        data-variants='{{ product.variants | json | escape }}'
+        data-size-index="{{ size_option_index }}"
+      >
+        <button
+          class="wishlist-toggle sticky-bar-wishlist"
+          type="button"
+          aria-pressed="false"
+          aria-label="{{ 'general.add_to_wishlist' | t | default: 'Add to wishlist' }}"
+        >
+          <svg class="wishlist-toggle__icon" viewBox="0 0 24 24" role="presentation" focusable="false">
+            <path d="M12 21.35 10.55 20.03C6.2 15.99 3 12.99 3 9.31 3 6.28 5.42 4 8.4 4A5.2 5.2 0 0 1 12 5.86 5.2 5.2 0 0 1 15.6 4C18.58 4 21 6.28 21 9.31c0 3.68-3.2 6.68-7.55 10.72z" />
+          </svg>
+        </button>
         <div class="product-title">
           {{ product.title }}
         </div>


### PR DESCRIPTION
## Summary
- add wishlist heart controls to desktop and reposition the mobile heart outside the sticky drawer
- provide product metadata attributes required for wishlist persistence
- adjust wishlist styling so inline hearts render correctly beside product titles
- ensure the mobile sticky wishlist button is not clipped behind surrounding content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cad41cf01883259c86107862cfe3d6