### PR TITLE
Revamp cart UI with inline editing experience

### DIFF
--- a/assets/cart-edit.js
+++ b/assets/cart-edit.js
@@ -1,0 +1,263 @@
+(function () {
+  if (window.CartEditInitialized) return;
+  window.CartEditInitialized = true;
+
+  const openButtonsSelector = '[data-cart-edit-open]';
+
+  class CartEditModalController {
+    constructor(dialog) {
+      this.dialog = dialog;
+      this.content = dialog.querySelector('[data-cart-edit-content]');
+      this.form = dialog.querySelector('[data-cart-edit-form]');
+      this.variantInput = this.form.querySelector('[data-cart-edit-variant-input]');
+      this.quantityInput = this.form.querySelector('[data-cart-edit-quantity]');
+      this.submitButton = this.form.querySelector('[data-cart-edit-submit]');
+      this.priceElement = dialog.querySelector('[data-cart-edit-price]');
+      this.variantTitleElement = dialog.querySelector('[data-cart-edit-variant-title]');
+      this.errorElement = dialog.querySelector('[data-cart-edit-error]');
+      this.galleryItems = Array.from(dialog.querySelectorAll('[data-media-id]'));
+      this.line = parseInt(this.content.dataset.line, 10);
+      this.moneyFormat = this.content.dataset.moneyFormat;
+      this.defaultSubmitLabel = this.submitButton?.dataset.defaultLabel || this.submitButton?.textContent;
+      this.soldOutLabel = this.submitButton?.dataset.soldOutLabel || this.defaultSubmitLabel;
+
+      try {
+        this.variants = JSON.parse(this.content.dataset.variantData || '[]');
+      } catch (error) {
+        console.warn('Unable to parse variant data for cart edit modal.', error);
+        this.variants = [];
+      }
+
+      this.onFormChange = this.onFormChange.bind(this);
+      this.onFormSubmit = this.onFormSubmit.bind(this);
+      this.onQuantityClick = this.onQuantityClick.bind(this);
+
+      this.form.addEventListener('change', this.onFormChange);
+      this.form.addEventListener('submit', this.onFormSubmit);
+      this.form.querySelectorAll('[data-quantity-change]').forEach((button) => {
+        button.addEventListener('click', this.onQuantityClick);
+      });
+
+      this.dialog.addEventListener('close', () => {
+        if (this.errorElement) {
+          this.errorElement.hidden = true;
+          this.errorElement.textContent = '';
+        }
+      });
+
+      this.updateVariant();
+    }
+
+    onQuantityClick(event) {
+      event.preventDefault();
+      const change = Number(event.currentTarget.dataset.quantityChange || 0);
+      const currentValue = Number(this.quantityInput.value || 1);
+      const step = Number(this.quantityInput.dataset.step || this.quantityInput.step || 1);
+      const min = Number(this.quantityInput.dataset.min || this.quantityInput.min || 1);
+      const maxAttr = this.quantityInput.dataset.max || this.quantityInput.max;
+      const max = maxAttr ? Number(maxAttr) : null;
+      let newValue = currentValue + change * step;
+
+      if (Number.isNaN(newValue)) {
+        newValue = min;
+      }
+
+      if (newValue < min) {
+        newValue = min;
+      }
+
+      if (max && newValue > max) {
+        newValue = max;
+      }
+
+      this.quantityInput.value = newValue;
+    }
+
+    onFormChange(event) {
+      if (event.target.matches('[data-cart-edit-option-value]')) {
+        this.updateVariant();
+      }
+    }
+
+    onFormSubmit(event) {
+      event.preventDefault();
+      if (!this.variantInput.value) {
+        this.showError(window.cartStrings?.error || 'Unable to update item.');
+        return;
+      }
+
+      const min = Number(this.quantityInput.dataset.min || this.quantityInput.min || 1);
+      const step = Number(this.quantityInput.dataset.step || this.quantityInput.step || 1);
+      const maxAttr = this.quantityInput.dataset.max || this.quantityInput.max;
+      const max = maxAttr ? Number(maxAttr) : null;
+      let quantity = Number(this.quantityInput.value);
+      if (Number.isNaN(quantity)) {
+        quantity = min;
+      }
+      if (quantity < min) {
+        quantity = min;
+      }
+      if (max && quantity > max) {
+        quantity = max;
+      }
+      if (step > 1) {
+        const remainder = (quantity - min) % step;
+        if (remainder !== 0) {
+          quantity = quantity - remainder + (remainder > 0 ? 0 : step);
+        }
+      }
+      const cartItemsElement = document.querySelector('cart-items');
+
+      if (!cartItemsElement || typeof cartItemsElement.updateQuantity !== 'function') {
+        this.showError(window.cartStrings?.error || 'Unable to update item.');
+        return;
+      }
+
+      this.setSubmitting(true);
+      cartItemsElement.updateQuantity(this.line, quantity, 'updates[]', this.variantInput.value);
+      this.dialog.close();
+      this.setSubmitting(false);
+    }
+
+    setSubmitting(isSubmitting) {
+      if (!this.submitButton) return;
+      this.submitButton.disabled = isSubmitting;
+      this.submitButton.classList.toggle('is-loading', isSubmitting);
+    }
+
+    showError(message) {
+      if (!this.errorElement) return;
+      this.errorElement.hidden = false;
+      this.errorElement.textContent = message;
+    }
+
+    updateVariant() {
+      const options = [];
+      const optionFields = this.form.querySelectorAll('[data-cart-edit-option]');
+      optionFields.forEach((_, index) => {
+        const input = this.form.querySelector(`input[name="option-${index}"]:checked`);
+        if (input) {
+          options[index] = input.value;
+        }
+      });
+
+      if (!optionFields.length) {
+        const currentId = Number(this.variantInput.value);
+        const defaultVariant = this.variants.find((variant) => variant.id === currentId) || this.variants[0];
+        if (defaultVariant) {
+          this.variantInput.value = defaultVariant.id;
+          this.updateAvailability(defaultVariant.available);
+          this.updateVariantDetails(defaultVariant);
+        }
+        return;
+      }
+
+      const matchingVariant = this.variants.find((variant) => {
+        return variant.options.every((value, index) => value === options[index]);
+      });
+
+      if (!matchingVariant) {
+        this.variantInput.value = '';
+        this.updateAvailability(false);
+        return;
+      }
+
+      this.variantInput.value = matchingVariant.id;
+      this.updateAvailability(matchingVariant.available);
+      this.updateVariantDetails(matchingVariant);
+    }
+
+    updateAvailability(isAvailable) {
+      if (!this.submitButton) return;
+      this.submitButton.disabled = !isAvailable;
+      this.submitButton.textContent = isAvailable ? this.defaultSubmitLabel : this.soldOutLabel;
+    }
+
+    updateVariantDetails(variant) {
+      if (this.variantTitleElement) {
+        this.variantTitleElement.textContent = variant.title;
+      }
+
+      if (this.priceElement) {
+        this.priceElement.textContent = this.formatMoney(variant.price);
+      }
+
+      if (this.quantityInput && variant.quantity_rule) {
+        const { min, max, increment } = variant.quantity_rule;
+
+        if (typeof min === 'number') {
+          this.quantityInput.min = min;
+          this.quantityInput.dataset.min = min;
+        } else {
+          this.quantityInput.removeAttribute('min');
+          delete this.quantityInput.dataset.min;
+        }
+
+        if (typeof increment === 'number') {
+          this.quantityInput.step = increment;
+          this.quantityInput.dataset.step = increment;
+        } else {
+          this.quantityInput.step = 1;
+          this.quantityInput.dataset.step = 1;
+        }
+
+        if (typeof max === 'number') {
+          this.quantityInput.max = max;
+          this.quantityInput.dataset.max = max;
+        } else {
+          this.quantityInput.removeAttribute('max');
+          delete this.quantityInput.dataset.max;
+        }
+
+        const currentValue = Number(this.quantityInput.value);
+        if (!Number.isNaN(currentValue) && typeof min === 'number' && currentValue < min) {
+          this.quantityInput.value = min;
+        }
+      } else if (this.quantityInput) {
+        this.quantityInput.removeAttribute('min');
+        delete this.quantityInput.dataset.min;
+        this.quantityInput.step = 1;
+        this.quantityInput.dataset.step = 1;
+        this.quantityInput.removeAttribute('max');
+        delete this.quantityInput.dataset.max;
+      }
+
+      if (this.galleryItems.length) {
+        const targetId = variant.featured_media ? String(variant.featured_media.id) : '';
+        this.galleryItems.forEach((item) => {
+          item.classList.toggle('is-active', targetId && item.dataset.mediaId === targetId);
+        });
+      }
+    }
+
+    formatMoney(value) {
+      if (typeof Shopify !== 'undefined' && typeof Shopify.formatMoney === 'function') {
+        return Shopify.formatMoney(value, this.moneyFormat || window.theme?.moneyFormat);
+      }
+
+      const amount = (Number(value) / 100).toFixed(2);
+      return this.moneyFormat ? this.moneyFormat.replace('{{amount}}', amount) : amount;
+    }
+  }
+
+  const controllers = new WeakMap();
+
+  function getController(dialog) {
+    if (!controllers.has(dialog)) {
+      controllers.set(dialog, new CartEditModalController(dialog));
+    }
+    return controllers.get(dialog);
+  }
+
+  document.addEventListener('click', (event) => {
+    const trigger = event.target.closest(openButtonsSelector);
+    if (!trigger) return;
+    event.preventDefault();
+    const targetId = trigger.getAttribute('data-cart-edit-open');
+    if (!targetId) return;
+    const dialog = document.getElementById(targetId);
+    if (!dialog || typeof dialog.showModal !== 'function') return;
+    getController(dialog);
+    dialog.showModal();
+  });
+})();

--- a/assets/cart-modern.css
+++ b/assets/cart-modern.css
@@ -1,0 +1,382 @@
+.cart-modern__list {
+  display: grid;
+  gap: 2rem;
+}
+
+.cart-modern-card {
+  display: grid;
+  grid-template-columns: minmax(120px, 160px) 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  background: var(--color-base-background-1, #fff);
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.04);
+  position: relative;
+}
+
+.cart-modern-card__media {
+  position: relative;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.cart-modern-card__image {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f5f5f5;
+}
+
+.cart-modern-card__img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.cart-modern-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cart-modern-card__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cart-modern-card__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cart-modern-card__name {
+  font-size: clamp(1.1rem, 1.1vw + 1rem, 1.4rem);
+  line-height: 1.3;
+  color: var(--color-foreground, #111);
+}
+
+.cart-modern-card__pricing {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.cart-modern-card__price {
+  font-size: 1.125rem;
+}
+
+.cart-modern-card__price-old {
+  font-size: 0.95rem;
+  color: rgba(17, 17, 17, 0.55);
+  text-decoration: line-through;
+}
+
+.cart-modern-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.cart-modern-card__icon-button {
+  background: none;
+  border: none;
+  padding: 0.35rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  color: currentColor;
+}
+
+.cart-modern-card__icon-button:hover,
+.cart-modern-card__icon-button:focus-visible {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.cart-modern-card__bottom {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cart-modern-card__quantity {
+  flex: 1 1 240px;
+  max-width: 320px;
+}
+
+.cart-modern-card__total {
+  flex: 1 1 160px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.cart-modern-card .cart-item__price-wrapper {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cart-modern-card__options {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: rgba(17, 17, 17, 0.65);
+}
+
+.cart-modern-card__vendor {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(17, 17, 17, 0.6);
+}
+
+.cart-modern-card__media-link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+/* Modal */
+.cart-edit-modal {
+  border: none;
+  padding: 0;
+  border-radius: 1.5rem;
+  max-width: min(720px, 92vw);
+  width: 100%;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+}
+
+.cart-edit-modal::backdrop {
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.cart-edit-modal__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.cart-edit-modal__back {
+  background: none;
+  border: none;
+  padding: 0.35rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.cart-edit-modal__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.cart-edit-modal__content {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2rem;
+  padding: 1.5rem;
+}
+
+.cart-edit-modal__gallery {
+  display: grid;
+  gap: 1rem;
+}
+
+.cart-edit-modal__media-item {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 2px solid transparent;
+}
+
+.cart-edit-modal__media-item.is-active {
+  border-color: rgba(17, 17, 17, 0.85);
+}
+
+.cart-edit-modal__media-item img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.cart-edit-modal__info {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cart-edit-modal__info-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cart-edit-modal__price {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.cart-edit-modal__product {
+  font-size: 1rem;
+  color: rgba(17, 17, 17, 0.7);
+}
+
+.cart-edit-modal__variant {
+  font-size: 0.95rem;
+  color: rgba(17, 17, 17, 0.6);
+}
+
+.cart-edit-modal__options {
+  display: grid;
+  gap: 1rem;
+}
+
+.cart-edit-modal__option {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.cart-edit-modal__option legend {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.cart-edit-modal__option-values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cart-edit-modal__option-values--swatches .swatch-input__label {
+  width: 42px;
+  height: 42px;
+}
+
+.cart-edit-modal__radio {
+  display: none;
+}
+
+.cart-edit-modal__radio-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 0.5rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  cursor: pointer;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.cart-edit-modal__radio:checked + .cart-edit-modal__radio-label {
+  background: #111;
+  color: #fff;
+  border-color: #111;
+}
+
+.cart-edit-modal__quantity {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cart-edit-modal__quantity-control {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.06);
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.cart-edit-modal__quantity-btn {
+  background: none;
+  border: none;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.cart-edit-modal__quantity-btn:hover,
+.cart-edit-modal__quantity-btn:focus-visible {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.cart-edit-modal__quantity-control input {
+  width: 64px;
+  border: none;
+  background: transparent;
+  text-align: center;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.cart-edit-modal__submit {
+  width: 100%;
+  justify-content: center;
+  font-size: 1rem;
+}
+
+.cart-edit-modal__error {
+  color: #b00020;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .cart-modern-card {
+    grid-template-columns: 120px 1fr;
+    gap: 1rem;
+  }
+
+  .cart-modern-card__bottom {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cart-modern-card__quantity,
+  .cart-modern-card__total {
+    width: 100%;
+    max-width: none;
+  }
+
+  .cart-modern-card__total {
+    justify-content: flex-start;
+  }
+
+  .cart-edit-modal__content {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .cart-modern-card {
+    grid-template-columns: 1fr;
+  }
+
+  .cart-modern-card__media {
+    height: 220px;
+  }
+
+  .cart-modern-card__actions {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .cart-edit-modal {
+    border-radius: 1rem;
+  }
+}

--- a/assets/cart.js
+++ b/assets/cart.js
@@ -146,12 +146,18 @@ class CartItems extends HTMLElement {
   updateQuantity(line, quantity, name, variantId) {
     this.enableLoading(line);
 
-    const body = JSON.stringify({
+    const bodyPayload = {
       line,
       quantity,
       sections: this.getSectionsToRender().map((section) => section.section),
       sections_url: window.location.pathname,
-    });
+    };
+
+    if (variantId) {
+      bodyPayload.id = variantId;
+    }
+
+    const body = JSON.stringify(bodyPayload);
 
     fetch(`${routes.cart_change_url}`, { ...fetchConfig(), ...{ body } })
       .then((response) => {

--- a/assets/icon-edit.svg
+++ b/assets/icon-edit.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M13.7071 2.29289C14.0976 1.90237 14.7308 1.90237 15.1213 2.29289L17.7071 4.87868C18.0976 5.2692 18.0976 5.90237 17.7071 6.29289L7.41421 16.5858C7.22664 16.7734 6.973 16.8787 6.70711 16.8787H4.12132C3.56903 16.8787 3.12132 16.431 3.12132 15.8787V13.2929C3.12132 13.027 3.22664 12.7734 3.41421 12.5858L13.7071 2.29289Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M11 4L15 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -309,6 +309,8 @@
       "new_estimated_total": "New estimated total",
       "note": "Order special instructions",
       "checkout": "Check out",
+      "edit": "Edit item",
+      "update_item": "Update item",
       "empty": "Your cart is empty",
       "cart_error": "There was an error while updating your cart. Please try again.",
       "cart_quantity_error_html": "You can only add {{ quantity }} of this item to your cart.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -289,6 +289,8 @@
       "remove_title": "Eliminar {{ title }}",
       "note": "Instrucciones especiales del pedido",
       "checkout": "Pagar pedido",
+      "edit": "Editar",
+      "update_item": "Actualizar artículo",
       "empty": "Tu carrito esta vacío",
       "cart_error": "Hubo un error al actualizar tu carrito de compra. Inténtalo de nuevo.",
       "cart_quantity_error_html": "Solo puedes agregar {{ quantity }} de este artículo a tu carrito.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -289,6 +289,8 @@
       "remove_title": "Remover {{ title }}",
       "note": "Instruções especiais do pedido",
       "checkout": "Finalizar a compra",
+      "edit": "Editar",
+      "update_item": "Atualizar item",
       "empty": "O carrinho está vazio",
       "cart_error": "Ocorreu um erro ao atualizar o carrinho. Tente de novo.",
       "cart_quantity_error_html": "É possível adicionar apenas {{ quantity }} unidade(s) desse item ao carrinho.",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -300,6 +300,8 @@
       "remove_title": "Eliminar {{ title }}",
       "note": "Instruções especiais da encomenda",
       "checkout": "Finalizar a compra",
+      "edit": "Editar",
+      "update_item": "Atualizar artigo",
       "empty": "O seu carrinho está vazio",
       "cart_error": "Ocorreu um erro ao atualizar o seu carrinho. Tente novamente.",
       "cart_quantity_error_html": "É possível adicionar apenas {{ quantity }} unidade(s) deste item ao carrinho.",

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -4,6 +4,9 @@
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'component-discounts.css' | asset_url | stylesheet_tag }}
 {{ 'quantity-popover.css' | asset_url | stylesheet_tag }}
+{{ 'component-swatch.css' | asset_url | stylesheet_tag }}
+{{ 'component-swatch-input.css' | asset_url | stylesheet_tag }}
+{{ 'cart-modern.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
   .section-{{ section.id }}-padding {
@@ -24,6 +27,7 @@
 {%- endunless -%}
 
 <script src="{{ 'quantity-popover.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'cart-edit.js' | asset_url }}" defer="defer"></script>
 
 <cart-items class="gradient color-{{ section.settings.color_scheme }} isolate{% if cart == empty %} is-empty{% else %} section-{{ section.id }}-padding{% endif %}">
   <div class="page-width">
@@ -60,399 +64,281 @@
       <div class="cart__items" id="main-cart-items" data-id="{{ section.id }}">
         <div class="js-contents">
           {%- if cart != empty -%}
-            <table class="cart-items">
-              <caption class="visually-hidden">
-                {{ 'sections.cart.title' | t }}
-              </caption>
-              <thead>
-                <tr>
-                  <th class="caption-with-letter-spacing" colspan="2" scope="col">
-                    {{ 'sections.cart.headings.product' | t }}
-                  </th>
-                  <th class="medium-hide large-up-hide right caption-with-letter-spacing" colspan="1" scope="col">
-                    {{ 'sections.cart.headings.total' | t }}
-                  </th>
-                  <th
-                    class="cart-items__heading--wide cart-items__heading--quantity small-hide caption-with-letter-spacing"
-                    colspan="1"
-                    scope="col"
-                  >
-                    {{ 'sections.cart.headings.quantity' | t }}
-                  </th>
-                  <th class="small-hide right caption-with-letter-spacing" colspan="1" scope="col">
-                    {{ 'sections.cart.headings.total' | t }}
-                  </th>
-                </tr>
-              </thead>
+            <div class="cart-modern__list" role="list">
+              {%- for item in cart.items -%}
+                {%- liquid
+                  assign line_index = item.index | plus: 1
+                  assign has_qty_rules = false
+                  if item.variant.quantity_rule.increment > 1 or item.variant.quantity_rule.min > 1 or item.variant.quantity_rule.max != null
+                    assign has_qty_rules = true
+                  endif
 
-              <tbody>
-                {%- for item in cart.items -%}
-                  <tr class="cart-item" id="CartItem-{{ item.index | plus: 1 }}">
-                    <td class="cart-item__media">
-                      {% if item.image %}
-                        {% comment %} Leave empty space due to a:empty CSS display: none rule {% endcomment %}
-                        <a href="{{ item.url }}" class="cart-item__link" aria-hidden="true" tabindex="-1"> </a>
-                        <div class="cart-item__image-container gradient global-media-settings">
-                          <img
-                            src="{{ item.image | image_url: width: 300 }}"
-                            class="cart-item__image"
-                            alt="{{ item.image.alt | escape }}"
-                            loading="lazy"
-                            width="150"
-                            height="{{ 150 | divided_by: item.image.aspect_ratio | ceil }}"
-                          >
-                        </div>
-                      {% endif %}
-                    </td>
-
-                    <td class="cart-item__details">
-                      {%- if settings.show_vendor -%}
-                        <p class="caption-with-letter-spacing">{{ item.product.vendor }}</p>
-                      {%- endif -%}
-
-                      <a href="{{ item.url }}" class="cart-item__name h4 break">{{ item.product.title | escape }}</a>
-
-                      {%- if item.original_price != item.final_price -%}
-                        <div class="cart-item__discounted-prices">
-                          <span class="visually-hidden">
-                            {{ 'products.product.price.regular_price' | t }}
-                          </span>
-                          <s class="cart-item__old-price product-option">
-                            {{- item.original_price | money -}}
-                          </s>
-                          <span class="visually-hidden">
-                            {{ 'products.product.price.sale_price' | t }}
-                          </span>
-                          <strong class="cart-item__final-price product-option">
-                            {{ item.final_price | money }}
-                          </strong>
-                        </div>
-                      {%- else -%}
-                        <div class="product-option">
-                          {{ item.original_price | money }}
-                        </div>
-                      {%- endif -%}
-
-                      {%- if item.product.has_only_default_variant == false
-                        or item.properties.size != 0
-                        or item.selling_plan_allocation != null
-                      -%}
-                        <dl>
-                          {%- if item.product.has_only_default_variant == false -%}
-                            {%- for option in item.options_with_values -%}
-                              <div class="product-option">
-                                <dt>{{ option.name }}:</dt>
-                                <dd>{{ option.value }}</dd>
-                              </div>
-                            {%- endfor -%}
-                          {%- endif -%}
-
-                          {%- for property in item.properties -%}
-                            {%- assign property_first_char = property.first | slice: 0 -%}
-                            {%- if property.last != blank and property_first_char != '_' -%}
-                              <div class="product-option">
-                                <dt>{{ property.first }}:</dt>
-                                <dd>
-                                  {%- if property.last contains '/uploads/' -%}
-                                    <a href="{{ property.last }}" class="link" target="_blank">
-                                      {{ property.last | split: '/' | last }}
-                                    </a>
-                                  {%- else -%}
-                                    {{ property.last }}
-                                  {%- endif -%}
-                                </dd>
-                              </div>
-                            {%- endif -%}
-                          {%- endfor -%}
-                        </dl>
-
-                        <p class="product-option">{{ item.selling_plan_allocation.selling_plan.name }}</p>
-                      {%- endif -%}
-
-                      <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
-                        {%- for discount in item.line_level_discount_allocations -%}
-                          <li class="discounts__discount">
-                            {{- 'icon-discount.svg' | inline_asset_content -}}
-                            {{ discount.discount_application.title | escape }}
-                          </li>
-                        {%- endfor -%}
-                      </ul>
-                    </td>
-
-                    <td class="cart-item__totals right medium-hide large-up-hide">
-                      {%- render 'loading-spinner' -%}
-                      <div class="cart-item__price-wrapper">
-                        {%- if item.original_line_price != item.final_line_price -%}
-                          <dl class="cart-item__discounted-prices">
-                            <dt class="visually-hidden">
-                              {{ 'products.product.price.regular_price' | t }}
-                            </dt>
-                            <dd>
-                              <s class="cart-item__old-price price price--end">
-                                {{ item.original_line_price | money }}
-                              </s>
-                            </dd>
-                            <dt class="visually-hidden">
-                              {{ 'products.product.price.sale_price' | t }}
-                            </dt>
-                            <dd class="price price--end">
-                              {{ item.final_line_price | money }}
-                            </dd>
-                          </dl>
-                        {%- else -%}
-                          <span class="price price--end">
-                            {{ item.original_line_price | money }}
-                          </span>
-                        {%- endif -%}
-
-                        {%- if item.variant.available and item.unit_price_measurement -%}
-                          <div class="unit-price caption">
-                            <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                            {{ item.unit_price | money }}
-                            <span aria-hidden="true">/</span>
-                            <span class="visually-hidden"
-                              >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
-                            >
-                            {%- if item.unit_price_measurement.reference_value != 1 -%}
-                              {{- item.unit_price_measurement.reference_value -}}
-                            {%- endif -%}
-                            {{ item.unit_price_measurement.reference_unit }}
-                          </div>
-                        {%- endif -%}
+                  assign has_vol_pricing = false
+                  if item.variant.quantity_price_breaks.size > 0
+                    assign has_vol_pricing = true
+                  endif
+                -%}
+                <article class="cart-modern-card cart-item" id="CartItem-{{ line_index }}" role="listitem">
+                  <div class="cart-modern-card__media">
+                    {% if item.image %}
+                      <a href="{{ item.url }}" class="cart-modern-card__media-link" aria-hidden="true" tabindex="-1"></a>
+                      <div class="cart-modern-card__image gradient global-media-settings">
+                        <img
+                          src="{{ item.image | image_url: width: 300 }}"
+                          class="cart-modern-card__img"
+                          alt="{{ item.image.alt | escape }}"
+                          loading="lazy"
+                          width="150"
+                          height="{{ 150 | divided_by: item.image.aspect_ratio | ceil }}"
+                        >
                       </div>
-                    </td>
-                    {%- liquid
-                      assign has_qty_rules = false
-                      if item.variant.quantity_rule.increment > 1 or item.variant.quantity_rule.min > 1 or item.variant.quantity_rule.max != null
-                        assign has_qty_rules = true
-                      endif
-
-                      assign has_vol_pricing = false
-                      if item.variant.quantity_price_breaks.size > 0
-                        assign has_vol_pricing = true
-                      endif
-                    -%}
-                    <td class="cart-item__quantity{% if has_qty_rules or has_vol_pricing %} cart-item__quantity--info{% endif %}">
-                      <quantity-popover>
-                        <div class="cart-item__quantity-wrapper quantity-popover-wrapper">
-                          <label class="visually-hidden" for="Quantity-{{ item.index | plus: 1 }}">
-                            {{ 'products.product.quantity.label' | t }}
-                          </label>
-                          <div class="quantity-popover-container{% if has_qty_rules or has_vol_pricing %} quantity-popover-container--hover{% endif %}">
-                            {%- if has_qty_rules or has_vol_pricing -%}
-                              <button
-                                type="button"
-                                aria-expanded="false"
-                                class="quantity-popover__info-button quantity-popover__info-button--icon-only button button--tertiary small-hide medium-hide"
-                              >
-                                {{- 'icon-info.svg' | inline_asset_content -}}
-                              </button>
-                            {%- endif -%}
-                            <quantity-input class="quantity cart-quantity">
-                              <button class="quantity__button" name="minus" type="button">
-                                <span class="visually-hidden">
-                                  {{- 'products.product.quantity.decrease' | t: product: item.product.title | escape -}}
-                                </span>
-                                <span class="svg-wrapper">
-                                  {{- 'icon-minus.svg' | inline_asset_content -}}
-                                </span>
-                              </button>
-                              <input
-                                class="quantity__input"
-                                data-quantity-variant-id="{{ item.variant.id }}"
-                                type="number"
-                                name="updates[]"
-                                value="{{ item.quantity }}"
-                                {% # theme-check-disable %}
-                                data-cart-quantity="{{ cart | item_count_for_variant: item.variant.id }}"
-                                min="0"
-                                data-min="{{ item.variant.quantity_rule.min }}"
-                                {% if item.variant.quantity_rule.max != null %}
-                                  max="{{ item.variant.quantity_rule.max }}"
-                                {% endif %}
-                                step="{{ item.variant.quantity_rule.increment }}"
-                                {% # theme-check-enable %}
-                                aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
-                                id="Quantity-{{ item.index | plus: 1 }}"
-                                data-index="{{ item.index | plus: 1 }}"
-                              >
-                              <button class="quantity__button" name="plus" type="button">
-                                <span class="visually-hidden">
-                                  {{- 'products.product.quantity.increase' | t: product: item.product.title | escape -}}
-                                </span>
-                                <span class="svg-wrapper">
-                                  {{- 'icon-plus.svg' | inline_asset_content -}}
-                                </span>
-                              </button>
-                            </quantity-input>
-                          </div>
-                          <cart-remove-button
-                            id="Remove-{{ item.index | plus: 1 }}"
-                            data-index="{{ item.index | plus: 1 }}"
-                          >
-                            <a
-                              href="{{ item.url_to_remove }}"
-                              class="button button--tertiary"
-                              aria-label="{{ 'sections.cart.remove_title' | t: title: item.title | escape }}"
-                            >
-                              <span class="svg-wrapper">
-                                {{- 'icon-remove.svg' | inline_asset_content -}}
-                              </span>
-                            </a>
-                          </cart-remove-button>
+                    {% endif %}
+                  </div>
+                  <div class="cart-modern-card__body">
+                    <div class="cart-modern-card__top">
+                      <div class="cart-modern-card__title-group">
+                        {%- if settings.show_vendor -%}
+                          <p class="caption-with-letter-spacing cart-modern-card__vendor">{{ item.product.vendor }}</p>
+                        {%- endif -%}
+                        <a href="{{ item.url }}" class="cart-modern-card__name h4 break">{{ item.product.title | escape }}</a>
+                        <div class="cart-modern-card__pricing">
+                          {%- if item.original_price != item.final_price -%}
+                            <span class="cart-modern-card__price-old">{{ item.original_price | money }}</span>
+                            <span class="cart-modern-card__price">{{ item.final_price | money }}</span>
+                          {%- else -%}
+                            <span class="cart-modern-card__price">{{ item.original_price | money }}</span>
+                          {%- endif -%}
                         </div>
-                        {%- if has_qty_rules or has_vol_pricing -%}
+                        {%- if item.product.has_only_default_variant == false or item.properties.size != 0 or item.selling_plan_allocation != null -%}
+                          <dl class="cart-modern-card__options">
+                            {%- if item.product.has_only_default_variant == false -%}
+                              {%- for option in item.options_with_values -%}
+                                <div class="product-option">
+                                  <dt>{{ option.name }}:</dt>
+                                  <dd>{{ option.value }}</dd>
+                                </div>
+                              {%- endfor -%}
+                            {%- endif -%}
+                            {%- for property in item.properties -%}
+                              {%- assign property_first_char = property.first | slice: 0 -%}
+                              {%- if property.last != blank and property_first_char != '_' -%}
+                                <div class="product-option">
+                                  <dt>{{ property.first }}:</dt>
+                                  <dd>
+                                    {%- if property.last contains '/uploads/' -%}
+                                      <a href="{{ property.last }}" class="link" target="_blank">
+                                        {{ property.last | split: '/' | last }}
+                                      </a>
+                                    {%- else -%}
+                                      {{ property.last }}
+                                    {%- endif -%}
+                                  </dd>
+                                </div>
+                              {%- endif -%}
+                            {%- endfor -%}
+                          </dl>
+                          <p class="product-option">{{ item.selling_plan_allocation.selling_plan.name }}</p>
+                        {%- endif -%}
+                        <ul class="discounts list-unstyled" role="list" aria-label="{{ 'customer.order.discount' | t }}">
+                          {%- for discount in item.line_level_discount_allocations -%}
+                            <li class="discounts__discount">
+                              {{- 'icon-discount.svg' | inline_asset_content -}}
+                              {{ discount.discount_application.title | escape }}
+                            </li>
+                          {%- endfor -%}
+                        </ul>
+                      </div>
+                      <div class="cart-modern-card__actions">
+                        <button
+                          type="button"
+                          class="cart-modern-card__icon-button"
+                          aria-label="{{ 'sections.cart.edit' | t: title: item.product.title | default: 'Edit item' }}"
+                          data-cart-edit-open="CartEdit-{{ line_index }}"
+                        >
+                          {{- 'icon-edit.svg' | inline_asset_content -}}
+                        </button>
+                        <cart-remove-button id="Remove-{{ line_index }}" data-index="{{ line_index }}">
                           <button
                             type="button"
-                            class="quantity-popover__info-button quantity-popover__info-button--icon-with-label button button--tertiary large-up-hide"
-                            aria-expanded="false"
+                            class="cart-modern-card__icon-button"
+                            aria-label="{{ 'sections.cart.remove_title' | t: title: item.title | escape }}"
                           >
-                            {{- 'icon-info.svg' | inline_asset_content -}}
-                            <span>
-                              {%- if has_vol_pricing -%}
-                                {{ 'products.product.volume_pricing.note' | t }}
-                              {%- elsif has_qty_rules -%}
-                                {{ 'products.product.quantity.note' | t }}
-                              {%- endif -%}
-                            </span>
+                            {{- 'icon-remove.svg' | inline_asset_content -}}
                           </button>
-                        {%- endif -%}
-                        {%- if has_vol_pricing or has_qty_rules -%}
-                          <div
-                            class="cart-items__info global-settings-popup quantity-popover__info"
-                            tabindex="-1"
-                            hidden
-                          >
-                            {%- if has_qty_rules == false -%}
-                              <span class="volume-pricing-label caption">
-                                {{- 'products.product.volume_pricing.title' | t -}}
-                              </span>
-                            {%- endif -%}
-                            <div class="quantity__rules caption">
-                              {%- if item.variant.quantity_rule.increment > 1 -%}
-                                <span class="divider">
-                                  {{-
-                                    'products.product.quantity.multiples_of'
-                                    | t: quantity: item.variant.quantity_rule.increment
-                                  -}}
-                                </span>
+                        </cart-remove-button>
+                      </div>
+                    </div>
+
+                    <div class="cart-modern-card__bottom">
+                      <div class="cart-modern-card__quantity">
+                        <quantity-popover>
+                          <div class="cart-item__quantity-wrapper quantity-popover-wrapper">
+                            <label class="visually-hidden" for="Quantity-{{ line_index }}">
+                              {{ 'products.product.quantity.label' | t }}
+                            </label>
+                            <div class="quantity-popover-container{% if has_qty_rules or has_vol_pricing %} quantity-popover-container--hover{% endif %}">
+                              {%- if has_qty_rules or has_vol_pricing -%}
+                                <button
+                                  type="button"
+                                  aria-expanded="false"
+                                  class="quantity-popover__info-button quantity-popover__info-button--icon-only button button--tertiary small-hide medium-hide"
+                                >
+                                  {{- 'icon-info.svg' | inline_asset_content -}}
+                                </button>
                               {%- endif -%}
-                              {%- if item.variant.quantity_rule.min > 1 -%}
-                                <span class="divider">
-                                  {{-
-                                    'products.product.quantity.min_of'
-                                    | t: quantity: item.variant.quantity_rule.min
-                                  -}}
-                                </span>
-                              {%- endif -%}
-                              {%- if item.variant.quantity_rule.max != null -%}
-                                <span class="divider">
-                                  {{-
-                                    'products.product.quantity.max_of'
-                                    | t: quantity: item.variant.quantity_rule.max
-                                  -}}
-                                </span>
-                              {%- endif -%}
+                              <quantity-input class="quantity cart-quantity">
+                                <button class="quantity__button" name="minus" type="button">
+                                  <span class="visually-hidden">
+                                    {{- 'products.product.quantity.decrease' | t: product: item.product.title | escape -}}
+                                  </span>
+                                  <span class="svg-wrapper">
+                                    {{- 'icon-minus.svg' | inline_asset_content -}}
+                                  </span>
+                                </button>
+                                <input
+                                  class="quantity__input"
+                                  data-quantity-variant-id="{{ item.variant.id }}"
+                                  type="number"
+                                  name="updates[]"
+                                  value="{{ item.quantity }}"
+                                  {% # theme-check-disable %}
+                                  data-cart-quantity="{{ cart | item_count_for_variant: item.variant.id }}"
+                                  min="0"
+                                  data-min="{{ item.variant.quantity_rule.min }}"
+                                  {% if item.variant.quantity_rule.max != null %}
+                                    max="{{ item.variant.quantity_rule.max }}"
+                                  {% endif %}
+                                  step="{{ item.variant.quantity_rule.increment }}"
+                                  {% # theme-check-enable %}
+                                  aria-label="{{ 'products.product.quantity.input_label' | t: product: item.product.title | escape }}"
+                                  id="Quantity-{{ line_index }}"
+                                  data-index="{{ line_index }}"
+                                >
+                                <button class="quantity__button" name="plus" type="button">
+                                  <span class="visually-hidden">
+                                    {{- 'products.product.quantity.increase' | t: product: item.product.title | escape -}}
+                                  </span>
+                                  <span class="svg-wrapper">
+                                    {{- 'icon-plus.svg' | inline_asset_content -}}
+                                  </span>
+                                </button>
+                              </quantity-input>
                             </div>
+                          </div>
+                          {%- if has_qty_rules or has_vol_pricing -%}
                             <button
-                              class="button-close button button--tertiary large-up-hide"
                               type="button"
-                              aria-label="{{ 'accessibility.close' | t }}"
+                              class="quantity-popover__info-button quantity-popover__info-button--icon-with-label button button--tertiary large-up-hide"
+                              aria-expanded="false"
                             >
-                              <span class="svg-wrapper">
-                                {{- 'icon-close.svg' | inline_asset_content -}}
+                              {{- 'icon-info.svg' | inline_asset_content -}}
+                              <span>
+                                {%- if has_vol_pricing -%}
+                                  {{ 'products.product.volume_pricing.note' | t }}
+                                {%- elsif has_qty_rules -%}
+                                  {{ 'products.product.quantity.note' | t }}
+                                {%- endif -%}
                               </span>
                             </button>
-                            {%- if item.variant.quantity_price_breaks.size > 0 -%}
-                              <volume-pricing class="parent-display">
-                                <ul class="list-unstyled">
-                                  <li>
-                                    <span>{{ item.variant.quantity_rule.min }}+</span>
-                                    {%- assign price = item.variant.price | money_with_currency -%}
-                                    <span> {{ 'sections.quick_order_list.each' | t: money: price }}</span>
-                                  </li>
-                                  {%- for price_break in item.variant.quantity_price_breaks -%}
+                          {%- endif -%}
+                          {%- if has_vol_pricing or has_qty_rules -%}
+                            <div class="cart-items__info global-settings-popup quantity-popover__info" tabindex="-1" hidden>
+                              {%- if has_qty_rules == false -%}
+                                <span class="volume-pricing-label caption">
+                                  {{- 'products.product.volume_pricing.title' | t -}}
+                                </span>
+                              {%- endif -%}
+                              <div class="quantity__rules caption">
+                                {%- if item.variant.quantity_rule.increment > 1 -%}
+                                  <span class="divider">
+                                    {{- 'products.product.quantity.multiples_of' | t: quantity: item.variant.quantity_rule.increment -}}
+                                  </span>
+                                {%- endif -%}
+                                {%- if item.variant.quantity_rule.min > 1 -%}
+                                  <span class="divider">
+                                    {{- 'products.product.quantity.min_of' | t: quantity: item.variant.quantity_rule.min -}}
+                                  </span>
+                                {%- endif -%}
+                                {%- if item.variant.quantity_rule.max != null -%}
+                                  <span class="divider">
+                                    {{- 'products.product.quantity.max_of' | t: quantity: item.variant.quantity_rule.max -}}
+                                  </span>
+                                {%- endif -%}
+                              </div>
+                              <button class="button-close button button--tertiary large-up-hide" type="button" aria-label="{{ 'accessibility.close' | t }}">
+                                <span class="svg-wrapper">
+                                  {{- 'icon-close.svg' | inline_asset_content -}}
+                                </span>
+                              </button>
+                              {%- if item.variant.quantity_price_breaks.size > 0 -%}
+                                <volume-pricing class="parent-display">
+                                  <ul class="list-unstyled">
                                     <li>
-                                      <span>
-                                        {{- price_break.minimum_quantity -}}
-                                        <span aria-hidden="true">+</span></span
-                                      >
-                                      {%- assign price = price_break.price | money_with_currency -%}
+                                      <span>{{ item.variant.quantity_rule.min }}+</span>
+                                      {%- assign price = item.variant.price | money_with_currency -%}
                                       <span> {{ 'sections.quick_order_list.each' | t: money: price }}</span>
                                     </li>
-                                  {%- endfor -%}
-                                </ul>
-                              </volume-pricing>
-                            {%- endif -%}
+                                    {%- for price_break in item.variant.quantity_price_breaks -%}
+                                      <li>
+                                        <span>{{- price_break.minimum_quantity -}}<span aria-hidden="true">+</span></span>
+                                        {%- assign price = price_break.price | money_with_currency -%}
+                                        <span> {{ 'sections.quick_order_list.each' | t: money: price }}</span>
+                                      </li>
+                                    {%- endfor -%}
+                                  </ul>
+                                </volume-pricing>
+                              {%- endif -%}
+                            </div>
+                          {%- endif -%}
+                          <div class="cart-item__error" id="Line-item-error-{{ line_index }}" role="alert">
+                            <small class="cart-item__error-text"></small>
+                            <span class="svg-wrapper">
+                              {{- 'icon-error.svg' | inline_asset_content -}}
+                            </span>
                           </div>
-                        {%- endif -%}
-                        <div class="cart-item__error" id="Line-item-error-{{ item.index | plus: 1 }}" role="alert">
-                          <small class="cart-item__error-text"></small>
-                          <span class="svg-wrapper">
-                            {{- 'icon-error.svg' | inline_asset_content -}}
-                          </span>
-                        </div>
-                      </quantity-popover>
-                    </td>
-
-                    <td class="cart-item__totals right small-hide">
-                      {%- render 'loading-spinner' -%}
-                      <div class="cart-item__price-wrapper">
-                        {%- if item.original_line_price != item.final_line_price -%}
-                          <dl class="cart-item__discounted-prices">
-                            <dt class="visually-hidden">
-                              {{ 'products.product.price.regular_price' | t }}
-                            </dt>
-                            <dd>
-                              <s class="cart-item__old-price price price--end">
-                                {{ item.original_line_price | money }}
-                              </s>
-                            </dd>
-                            <dt class="visually-hidden">
-                              {{ 'products.product.price.sale_price' | t }}
-                            </dt>
-                            <dd class="price price--end">
-                              {{ item.final_line_price | money }}
-                            </dd>
-                          </dl>
-                        {%- else -%}
-                          <span class="price price--end">
-                            {{ item.original_line_price | money }}
-                          </span>
-                        {%- endif -%}
-
-                        {%- if item.variant.available and item.unit_price_measurement -%}
-                          <div class="unit-price caption">
-                            <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
-                            {{ item.unit_price | money }}
-                            <span aria-hidden="true">/</span>
-                            <span class="visually-hidden"
-                              >&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span
-                            >
-                            {%- if item.unit_price_measurement.reference_value != 1 -%}
-                              {{- item.unit_price_measurement.reference_value -}}
-                            {%- endif -%}
-                            {{ item.unit_price_measurement.reference_unit }}
-                          </div>
-                        {%- endif -%}
+                        </quantity-popover>
                       </div>
-                    </td>
-                  </tr>
-                {%- endfor -%}
-              </tbody>
-            </table>
+                      <div class="cart-modern-card__total">
+                        {%- render 'loading-spinner' -%}
+                        <div class="cart-item__price-wrapper">
+                          {%- if item.original_line_price != item.final_line_price -%}
+                            <dl class="cart-item__discounted-prices">
+                              <dt class="visually-hidden">{{ 'products.product.price.regular_price' | t }}</dt>
+                              <dd>
+                                <s class="cart-item__old-price price price--end">{{ item.original_line_price | money }}</s>
+                              </dd>
+                              <dt class="visually-hidden">{{ 'products.product.price.sale_price' | t }}</dt>
+                              <dd class="price price--end">{{ item.final_line_price | money }}</dd>
+                            </dl>
+                          {%- else -%}
+                            <span class="price price--end">{{ item.final_line_price | money }}</span>
+                          {%- endif -%}
+                          {%- if item.variant.available and item.unit_price_measurement -%}
+                            <div class="unit-price caption">
+                              <span class="visually-hidden">{{ 'products.product.price.unit_price' | t }}</span>
+                              {{ item.unit_price | money }}
+                              <span aria-hidden="true">/</span>
+                              <span class="visually-hidden">&nbsp;{{ 'accessibility.unit_price_separator' | t }}&nbsp;</span>
+                              {%- if item.unit_price_measurement.reference_value != 1 -%}
+                                {{- item.unit_price_measurement.reference_value -}}
+                              {%- endif -%}
+                              {{ item.unit_price_measurement.reference_unit }}
+                            </div>
+                          {%- endif -%}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {%- render 'cart-item-edit-modal', item: item, line_index: line_index -%}
+                </article>
+              {%- endfor -%}
+            </div>
           {%- endif -%}
         </div>
       </div>
-
       <p class="visually-hidden" id="cart-live-region-text" aria-live="polite" role="status"></p>
-      <p
-        class="visually-hidden"
-        id="shopping-cart-line-item-status"
-        aria-live="polite"
-        aria-hidden="true"
-        role="status"
-      >
+      <p class="visually-hidden" id="shopping-cart-line-item-status" aria-live="polite" role="status" aria-hidden="true">
         {{ 'accessibility.loading' | t }}
       </p>
     </form>
@@ -462,36 +348,32 @@
 {% schema %}
 {
   "name": "t:sections.main-cart-items.name",
+  "tag": "section",
+  "class": "section",
   "settings": [
     {
       "type": "color_scheme",
       "id": "color_scheme",
-      "label": "t:sections.all.colors.label",
-      "default": "scheme-1"
-    },
-    {
-      "type": "header",
-      "content": "t:sections.all.padding.section_padding_heading"
+      "default": "scheme-1",
+      "label": "t:sections.all.colors.label"
     },
     {
       "type": "range",
       "id": "padding_top",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36,
       "min": 0,
       "max": 100,
-      "step": 4,
-      "unit": "px",
-      "label": "t:sections.all.padding.padding_top",
-      "default": 36
+      "unit": "px"
     },
     {
       "type": "range",
       "id": "padding_bottom",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36,
       "min": 0,
       "max": 100,
-      "step": 4,
-      "unit": "px",
-      "label": "t:sections.all.padding.padding_bottom",
-      "default": 36
+      "unit": "px"
     }
   ]
 }

--- a/snippets/cart-item-edit-modal.liquid
+++ b/snippets/cart-item-edit-modal.liquid
@@ -1,0 +1,133 @@
+{% assign product = item.product %}
+{% assign current_variant = item.variant %}
+{% assign current_media_id = current_variant.featured_media.id | default: product.featured_media.id %}
+<dialog
+  class="cart-edit-modal"
+  id="CartEdit-{{ line_index }}"
+  data-current-variant="{{ current_variant.id }}"
+>
+  <form method="dialog" class="cart-edit-modal__header">
+    <button type="submit" class="cart-edit-modal__back" aria-label="{{ 'accessibility.back' | t }}">
+      {{- 'icon-arrow.svg' | inline_asset_content -}}
+    </button>
+    <h2 class="cart-edit-modal__title">{{ 'sections.cart.edit' | t | default: 'Editar' }}</h2>
+  </form>
+  <div
+    class="cart-edit-modal__content"
+    data-cart-edit-content
+    data-variant-data='{{ product.variants | json | escape }}'
+    data-line="{{ line_index }}"
+    data-money-format="{{ shop.money_format | escape }}"
+  >
+    <div class="cart-edit-modal__gallery" data-cart-edit-gallery>
+      {%- for media in product.media -%}
+        {%- if media.preview_image -%}
+          <div class="cart-edit-modal__media-item{% if media.id == current_media_id %} is-active{% endif %}" data-media-id="{{ media.id }}">
+            <img
+              src="{{ media.preview_image | image_url: width: 600 }}"
+              alt="{{ media.alt | default: product.title | escape }}"
+              loading="lazy"
+              width="300"
+              height="{{ 300 | divided_by: media.preview_image.aspect_ratio | ceil }}"
+            >
+          </div>
+        {%- endif -%}
+      {%- endfor -%}
+    </div>
+    <div class="cart-edit-modal__info">
+      <div class="cart-edit-modal__info-header">
+        <p class="cart-edit-modal__price" data-cart-edit-price>
+          {{ current_variant.price | money }}
+        </p>
+        <p class="cart-edit-modal__product">{{ product.title | escape }}</p>
+        <p class="cart-edit-modal__variant" data-cart-edit-variant-title>{{ current_variant.title | escape }}</p>
+      </div>
+      <form
+        method="post"
+        action="{{ routes.cart_change_url }}"
+        class="cart-edit-modal__form"
+        id="CartEditForm-{{ line_index }}"
+        data-cart-edit-form
+      >
+        <input type="hidden" name="line" value="{{ line_index }}">
+        <input type="hidden" name="id" value="{{ current_variant.id }}" data-cart-edit-variant-input>
+        <div class="cart-edit-modal__options"{% if product.has_only_default_variant %} hidden{% endif %}>
+          {%- unless product.has_only_default_variant -%}
+          {%- for option in product.options_with_values -%}
+            {%- assign option_index = forloop.index0 -%}
+            {%- assign selected_value = current_variant.options[option_index] -%}
+            {%- assign swatch_count = option.values | map: 'swatch' | compact | size -%}
+            <fieldset class="cart-edit-modal__option" data-cart-edit-option>
+              <legend>{{ option.name }}</legend>
+              <div class="cart-edit-modal__option-values{% if swatch_count > 0 %} cart-edit-modal__option-values--swatches{% endif %}">
+                {%- for value in option.values -%}
+                  {%- assign option_raw_value = value.value | default: value -%}
+                  {%- assign option_label = option_raw_value | escape -%}
+                  {%- assign is_active = option_raw_value == selected_value -%}
+                  {%- assign option_id = 'CartEdit-' | append: line_index | append: '-' | append: option_index | append: '-' | append: forloop.index0 -%}
+                  {%- if swatch_count > 0 -%}
+                    {% render 'swatch-input',
+                      id: option_id,
+                      name: 'option-' | append: option_index,
+                      value: option_label,
+                      swatch: value.swatch,
+                      product_form_id: 'CartEditForm-' | append: line_index,
+                      checked: is_active,
+                      additional_props: 'data-cart-edit-option-value="' | append: option_label | append: '" data-option-index="' | append: option_index | append: '"'
+                    %}
+                  {%- else -%}
+                    <input
+                      type="radio"
+                      class="cart-edit-modal__radio"
+                      id="{{ option_id }}"
+                      name="option-{{ option_index }}"
+                      value="{{ option_label }}"
+                      {% if is_active %}checked{% endif %}
+                      data-cart-edit-option-value
+                      data-option-index="{{ option_index }}"
+                    >
+                    <label for="{{ option_id }}" class="cart-edit-modal__radio-label">{{ option_raw_value }}</label>
+                  {%- endif -%}
+                {%- endfor -%}
+              </div>
+            </fieldset>
+          {%- endfor -%}
+          {%- endunless -%}
+        </div>
+        <div class="cart-edit-modal__quantity">
+          <span>{{ 'products.product.quantity.label' | t }}</span>
+          <div class="cart-edit-modal__quantity-control">
+            <button type="button" class="cart-edit-modal__quantity-btn" data-quantity-change="-1" aria-label="{{ 'products.product.quantity.decrease' | t }}">
+              {{- 'icon-minus.svg' | inline_asset_content -}}
+            </button>
+            <input
+              type="number"
+              name="quantity"
+              min="{{ current_variant.quantity_rule.min }}"
+              {% if current_variant.quantity_rule.max != null %}max="{{ current_variant.quantity_rule.max }}"{% endif %}
+              step="{{ current_variant.quantity_rule.increment }}"
+              value="{{ item.quantity }}"
+              data-cart-edit-quantity
+              data-min="{{ current_variant.quantity_rule.min }}"
+              {% if current_variant.quantity_rule.max != null %}data-max="{{ current_variant.quantity_rule.max }}"{% endif %}
+              data-step="{{ current_variant.quantity_rule.increment }}"
+            >
+            <button type="button" class="cart-edit-modal__quantity-btn" data-quantity-change="1" aria-label="{{ 'products.product.quantity.increase' | t }}">
+              {{- 'icon-plus.svg' | inline_asset_content -}}
+            </button>
+          </div>
+        </div>
+        <button
+          type="submit"
+          class="button button--primary cart-edit-modal__submit"
+          data-cart-edit-submit
+          data-default-label="{{ 'sections.cart.update_item' | t | default: 'Atualizar' }}"
+          data-sold-out-label="{{ 'products.product.sold_out' | t }}"
+        >
+          {{ 'sections.cart.update_item' | t | default: 'Atualizar' }}
+        </button>
+        <p class="cart-edit-modal__error" role="alert" hidden data-cart-edit-error></p>
+      </form>
+    </div>
+  </div>
+</dialog>


### PR DESCRIPTION
## Summary
- replace the cart table with card-based styling, action icons, and per-item edit affordances
- add a cart edit modal with swatches, quantity controls, and variant-aware updates driven by a new script
- update cart logic, locale strings, and styles to support the refreshed interface

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd3e68bc4c8325894b68dac1f82420