### PR TITLE
Enable size drawer flow on desktop product page

### DIFF
--- a/assets/size-drawer.js
+++ b/assets/size-drawer.js
@@ -122,7 +122,9 @@
   }
 
   function updateProductFormVariant(sectionId, variantId) {
-    const form = document.getElementById(`product-form-${sectionId}`);
+    const form =
+      document.getElementById(`product-form-${sectionId}`) ||
+      document.getElementById(`desktop-product-form-${sectionId}`);
     if (!form) return;
     const input = form.querySelector('input[name="id"]');
     if (!input) return;

--- a/sections/desktop-product.liquid
+++ b/sections/desktop-product.liquid
@@ -645,43 +645,54 @@ document.addEventListener('DOMContentLoaded', function() {
     return;
   }
   
-  var fieldsets = variantPickerEl.querySelectorAll('.product-form__input');
+  var fieldsets = Array.from(
+    variantPickerEl.querySelectorAll('.product-form__input[data-option-position]')
+  );
+  if (!fieldsets.length) {
+    fieldsets = Array.from(variantPickerEl.querySelectorAll('.product-form__input'));
+  }
   if (!fieldsets.length) {
     console.warn("No product-form__input fieldsets found in variant-picker");
     return;
   }
-  
+
+  var totalOptions = Array.isArray(productData.options) ? productData.options.length : fieldsets.length;
+
   function getSelectedOptions() {
-    var selected = [];
-    fieldsets.forEach(function(fieldset) {
+    var selected = new Array(totalOptions).fill(null);
+    fieldsets.forEach(function(fieldset, index) {
+      var positionAttr = fieldset.getAttribute('data-option-position');
+      var optionIndex = parseInt(positionAttr || '', 10) - 1;
+      if (isNaN(optionIndex) || optionIndex < 0 || optionIndex >= selected.length) {
+        optionIndex = index;
+      }
+
+      var value = null;
       var select = fieldset.querySelector('select');
       if (select) {
-        if (select.value === "") {
-          selected.push(null);
-        } else {
-          selected.push(select.value.trim());
-        }
+        value = select.value ? select.value.trim() : null;
       } else {
-        var radios = fieldset.querySelectorAll('input[type="radio"]');
-        var found = false;
-        radios.forEach(function(radio) {
-          if (radio.checked) {
-            selected.push(radio.value.trim());
-            found = true;
-          }
-        });
-        if (!found) {
-          selected.push(null);
+        var checkedInput = fieldset.querySelector('input[type="radio"]:checked, input[type="checkbox"]:checked');
+        if (checkedInput) {
+          value = checkedInput.value ? checkedInput.value.trim() : null;
         }
+      }
+
+      if (optionIndex >= 0 && optionIndex < selected.length) {
+        selected[optionIndex] = value;
       }
     });
     return selected;
   }
-  
+
   function findVariant(selectedOptions) {
     return productData.variants.find(function(variant) {
       return variant.options.every(function(opt, idx) {
-        return String(selectedOptions[idx]).toLowerCase() === String(opt).toLowerCase();
+        var selectedValue = selectedOptions[idx];
+        if (selectedValue === null || selectedValue === undefined || selectedValue === '') {
+          return true;
+        }
+        return String(selectedValue).toLowerCase() === String(opt).toLowerCase();
       });
     });
   }
@@ -718,6 +729,16 @@ document.addEventListener('DOMContentLoaded', function() {
       el.addEventListener('change', updateVariant);
     });
   });
+
+  fieldsets.forEach(function(fieldset) {
+    var radios = fieldset.querySelectorAll('input[type="radio"]');
+    if (radios.length && !fieldset.querySelector('input[type="radio"]:checked')) {
+      radios[0].checked = true;
+      radios[0].dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+
+  updateVariant();
 });
 </script>
 

--- a/snippets/desktop-variant-picker.liquid
+++ b/snippets/desktop-variant-picker.liquid
@@ -16,6 +16,7 @@
   >
     {%- for option in product.options_with_values -%}
       {%- liquid
+        assign option_name_lower = option.name | downcase
         assign swatch_count = option.values | map: 'swatch' | compact | size
         assign picker_type = block.settings.picker_type
 
@@ -26,83 +27,89 @@
             assign picker_type = 'swatch'
           endif
         endif
-      -%}
-      
-      {%- comment %}
-        For Size options, force dropdown so we can add a placeholder.
-      {%- endcomment -%}
-      {%- if option.name contains "Size" -%}
-        {% assign picker_type = "button" %}
-      {%- endif -%}
-      
-      {%- comment %}
-        For Color options, force swatch dropdown so the swatch is shown.
-      {%- endcomment -%}
-      {%- if option.name contains "Color" or option.name contains "Cor" -%}
-        {% assign picker_type = "swatch" %}
-      {%- endif -%}
-      
-      {%- if picker_type == 'swatch' -%}
-        <fieldset class="js product-form__input product-form__input--swatch">
 
-          {% render 'product-variant-options',
-            product: product,
-            option: option,
-            block: block,
-            picker_type: picker_type
-          %}
-        </fieldset>
-      {%- elsif picker_type == 'button' -%}
-        <fieldset class="js product-form__input product-form__input--pill">
-          <legend class="form__label">{{ option.name }}</legend>
-          {% render 'product-variant-options',
-            product: product,
-            option: option,
-            block: block,
-            picker_type: picker_type
-          %}
-        </fieldset>
-      {%- else -%}
-        <div class="product-form__input product-form__input--dropdown">
-          <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
-            {{ option.name }}
-          </label>
-          <div class="select">
-            {%- if picker_type == 'swatch_dropdown' -%}
-              <span
-                data-selected-value
-                class="dropdown-swatch"
-              >
-                {% render 'swatch', swatch: option.selected_value.swatch, shape: block.settings.swatch_shape %}
+        assign is_size_option = false
+        if option_name_lower contains 'size' or option_name_lower contains 'tamanho' or option_name_lower contains 'talla'
+          assign is_size_option = true
+        endif
+
+        if option_name_lower contains 'color' or option_name_lower contains 'cor' or option_name_lower contains 'couleur'
+          assign picker_type = 'swatch'
+        endif
+      -%}
+
+      {%- unless is_size_option -%}
+        {%- if picker_type == 'swatch' -%}
+          <fieldset
+            class="js product-form__input product-form__input--swatch"
+            data-option-position="{{ option.position }}"
+            data-option-name="{{ option.name | escape }}"
+          >
+            <legend class="form__label">
+              {{ option.name }}:
+              <span data-selected-value>
+                {{- option.selected_value -}}
               </span>
-            {%- endif -%}
-            <select
-              id="Option-{{ section.id }}-{{ forloop.index0 }}"
-              class="select__select"
-              name="options[{{ option.name | escape }}]"
-              form="{{ product_form_id }}"
-            >
-              {%- comment %}
-                If this is a size option, insert a placeholder.
-              {%- endcomment -%}
-              {%- if option.name contains "Size" -%}
-                <option value="" disabled selected>Size</option>
+            </legend>
+            {% render 'product-variant-options',
+              product: product,
+              option: option,
+              block: block,
+              picker_type: picker_type
+            %}
+          </fieldset>
+        {%- elsif picker_type == 'button' -%}
+          <fieldset
+            class="js product-form__input product-form__input--pill"
+            data-option-position="{{ option.position }}"
+            data-option-name="{{ option.name | escape }}"
+          >
+            <legend class="form__label">{{ option.name }}</legend>
+            {% render 'product-variant-options',
+              product: product,
+              option: option,
+              block: block,
+              picker_type: picker_type
+            %}
+          </fieldset>
+        {%- else -%}
+          <div
+            class="product-form__input product-form__input--dropdown"
+            data-option-position="{{ option.position }}"
+            data-option-name="{{ option.name | escape }}"
+          >
+            <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
+              {{ option.name }}
+            </label>
+            <div class="select">
+              {%- if picker_type == 'swatch_dropdown' -%}
+                <span
+                  data-selected-value
+                  class="dropdown-swatch"
+                >
+                  {% render 'swatch', swatch: option.selected_value.swatch, shape: block.settings.swatch_shape %}
+                </span>
               {%- endif -%}
-              {% render 'product-variant-options',
-                product: product,
-                option: option,
-                block: block,
-                picker_type: picker_type
-              %}
-              
-            </select>
-            {% render 'size-chart-new', section_id: section.id %}
-            <span class="svg-wrapper">
-              {{- 'icon-caret.svg' | inline_asset_content -}}
-            </span>
+              <select
+                id="Option-{{ section.id }}-{{ forloop.index0 }}"
+                class="select__select"
+                name="options[{{ option.name | escape }}]"
+                form="{{ product_form_id }}"
+              >
+                {% render 'product-variant-options',
+                  product: product,
+                  option: option,
+                  block: block,
+                  picker_type: picker_type
+                %}
+              </select>
+              <span class="svg-wrapper">
+                {{- 'icon-caret.svg' | inline_asset_content -}}
+              </span>
+            </div>
           </div>
-        </div>
-      {%- endif -%}
+        {%- endif -%}
+      {%- endunless -%}
     {%- endfor -%}
 
     <script type="application/json" data-selected-variant>


### PR DESCRIPTION
## Summary
- hide size selectors from the desktop product variant picker while keeping color swatches visible
- sync the desktop product form with color selections and default the first swatch when none selected
- allow the shared size drawer script to target desktop product forms when adding variants to the cart

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b86759e88325a04c15da8d2500fd