### PR TITLE
Ensure size drawer targets correct product forms

### DIFF
--- a/assets/size-drawer.js
+++ b/assets/size-drawer.js
@@ -121,10 +121,43 @@
     }
   }
 
+  function findProductForm(sectionId) {
+    const data = getSectionData(sectionId);
+    let form = null;
+
+    if (data?.productFormId) {
+      form = document.getElementById(data.productFormId);
+    }
+
+    if (!form) {
+      form = document.getElementById(`product-form-${sectionId}`);
+    }
+
+    if (!form) {
+      const productFormElement = document.querySelector(
+        `product-form[data-section-id="${cssEscape(sectionId)}"]`
+      );
+      if (productFormElement) {
+        form = productFormElement.querySelector('form') || productFormElement;
+      }
+    }
+
+    if (!form && data?.productFormId) {
+      const fallback = document.querySelector(
+        `form[id="${cssEscape(data.productFormId)}"]`
+      );
+      if (fallback) {
+        form = fallback;
+      }
+    }
+
+    return form || null;
+  }
+
   function updateProductFormVariant(sectionId, variantId) {
-    const form = document.getElementById(`product-form-${sectionId}`);
+    const form = findProductForm(sectionId);
     if (!form) return;
-    const input = form.querySelector('input[name="id"]');
+    const input = form.querySelector?.('input[name="id"]');
     if (!input) return;
     input.value = variantId;
     input.dispatchEvent(new Event('change', { bubbles: true }));

--- a/snippets/buy-buttons.liquid
+++ b/snippets/buy-buttons.liquid
@@ -177,7 +177,7 @@
   {%- endif -%}
 
   <!-- Size Drawer (render at the end of buy-buttons) -->
-  {%- render 'size-drawer', product: product, section_id: section_id -%}
+  {%- render 'size-drawer', product: product, section_id: section_id, product_form_id: product_form_id -%}
   
   <!-- Load size drawer assets -->
   {{ 'size-drawer.css' | asset_url | stylesheet_tag }}

--- a/snippets/size-drawer.liquid
+++ b/snippets/size-drawer.liquid
@@ -1,3 +1,10 @@
+{%- liquid
+  assign drawer_product_form_id = product_form_id
+  if drawer_product_form_id == blank
+    assign drawer_product_form_id = 'product-form-' | append: section_id
+  endif
+-%}
+
 <div
   id="size-drawer-{{ section_id }}"
   class="size-drawer"
@@ -44,6 +51,7 @@
   window.themeSizeDrawerData['{{ section_id }}'] = {
     productId: {{ product.id }},
     sectionId: '{{ section_id }}',
+    productFormId: {{ drawer_product_form_id | json }},
     variants: {{ product.variants | json }},
     options: {{ product.options_with_values | json }},
     colorOptionIndex: -1,


### PR DESCRIPTION
## Summary
- pass the product form identifier into the reusable size drawer snippet
- update the drawer script to reliably locate the appropriate product form before setting the hidden variant input
- keep the drawer data initialisation resilient by defaulting to the standard product form id when one is not supplied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b86759e88325a04c15da8d2500fd