### PR TITLE
Fix size drawer integration with variant pickers

### DIFF
--- a/assets/size-drawer.js
+++ b/assets/size-drawer.js
@@ -73,6 +73,73 @@
 
   const getVariantSelectRoot = (sectionId) => document.getElementById(`variant-selects-${sectionId}`);
 
+  const setVariantOptionOnRoot = (root, option, value) => {
+    if (!root || !option) return;
+    const resolvedValue = getOptionValueString(value);
+    if (!resolvedValue) return;
+
+    const optionName = `${option.name}-${option.position}`;
+    const radioSelector = `input[name="${cssEscape(optionName)}"]`;
+    const radios = root.querySelectorAll(radioSelector);
+    if (radios.length) {
+      let target = Array.from(radios).find((input) => input.value === resolvedValue);
+      if (!target) {
+        target = Array.from(radios).find((input) => normalize(input.value) === normalize(resolvedValue));
+      }
+      if (target && !target.checked) {
+        target.checked = true;
+        target.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      return;
+    }
+
+    const selectName = `options[${option.name}]`;
+    const select = root.querySelector(`select[name="${cssEscape(selectName)}"]`);
+    if (select) {
+      let selectedValue = select.value;
+      if (selectedValue === resolvedValue || normalize(selectedValue) === normalize(resolvedValue)) {
+        return;
+      }
+
+      const matchingOption = Array.from(select.options).find(
+        (optionElement) =>
+          optionElement.value === resolvedValue || normalize(optionElement.value) === normalize(resolvedValue)
+      );
+
+      if (matchingOption) {
+        select.value = matchingOption.value;
+      } else {
+        select.value = resolvedValue;
+      }
+
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  };
+
+  const syncVariantOptionSelections = (sectionId, variant) => {
+    if (!sectionId || !variant || !Array.isArray(variant.options)) return;
+    const data = getSectionData(sectionId);
+    if (!data || !Array.isArray(data.options) || !data.options.length) return;
+
+    const escapedSectionId = cssEscape(sectionId);
+    let roots = Array.from(document.querySelectorAll(`variant-selects[data-section="${escapedSectionId}"]`));
+    const fallbackRoot = getVariantSelectRoot(sectionId);
+    if (fallbackRoot && !roots.includes(fallbackRoot)) {
+      roots.push(fallbackRoot);
+    }
+
+    if (!roots.length) return;
+
+    roots.forEach((root) => {
+      data.options.forEach((option, index) => {
+        if (!option) return;
+        const optionValue = variant.options[index];
+        if (optionValue == null) return;
+        setVariantOptionOnRoot(root, option, optionValue);
+      });
+    });
+  };
+
   function getSelectedOptionValue(sectionId, option) {
     const root = getVariantSelectRoot(sectionId);
     if (!root) {
@@ -95,22 +162,48 @@
   }
 
   function ensureState(sectionId) {
-    const trigger = document.querySelector(`[data-size-drawer-trigger="${sectionId}"]`);
     let state = stateBySection.get(sectionId);
     if (!state) {
       state = {
         lastFocused: null,
-        trigger,
-        originalLabel: trigger?.querySelector('span')?.textContent?.trim() || '',
-        resetTimer: null,
+        activeTrigger: null,
+        triggers: [],
+        triggerData: new Map(),
       };
       stateBySection.set(sectionId, state);
-    } else {
-      if (trigger) state.trigger = trigger;
-      if (!state.originalLabel && trigger) {
-        state.originalLabel = trigger.querySelector('span')?.textContent?.trim() || '';
-      }
     }
+
+    const triggers = Array.from(document.querySelectorAll(`[data-size-drawer-trigger="${sectionId}"]`));
+    state.triggers = triggers;
+
+    triggers.forEach((trigger) => {
+      if (!state.triggerData.has(trigger)) {
+        const labelText = trigger.querySelector('span')?.textContent?.trim() || '';
+        state.triggerData.set(trigger, {
+          originalLabel: labelText,
+          resetTimer: null,
+        });
+      } else {
+        const data = state.triggerData.get(trigger);
+        if (data && !data.originalLabel) {
+          data.originalLabel = trigger.querySelector('span')?.textContent?.trim() || '';
+        }
+      }
+    });
+
+    state.triggerData.forEach((data, trigger) => {
+      if (!triggers.includes(trigger)) {
+        if (data.resetTimer) {
+          clearTimeout(data.resetTimer);
+        }
+        state.triggerData.delete(trigger);
+      }
+    });
+
+    if (state.activeTrigger && !triggers.includes(state.activeTrigger)) {
+      state.activeTrigger = null;
+    }
+
     return state;
   }
 
@@ -126,7 +219,9 @@
     if (!form) return;
     const input = form.querySelector('input[name="id"]');
     if (!input) return;
-    input.value = variantId;
+    const stringValue = String(variantId);
+    if (input.value === stringValue) return;
+    input.value = stringValue;
     input.dispatchEvent(new Event('change', { bubbles: true }));
   }
 
@@ -251,18 +346,32 @@
     }
   }
 
-  function resetTriggerLabel(sectionId) {
+  function resetTriggerLabel(sectionId, targetTrigger) {
     const state = ensureState(sectionId);
-    if (state.resetTimer) {
-      clearTimeout(state.resetTimer);
-      state.resetTimer = null;
-    }
-    if (!state.trigger || !state.originalLabel) return;
-    const label = state.trigger.querySelector('span');
-    if (label) {
-      label.textContent = state.originalLabel;
-    }
-    state.trigger.classList.remove('choose-size-btn--added');
+    const triggers = targetTrigger ? [targetTrigger] : state.triggers;
+
+    triggers.forEach((trigger) => {
+      if (!trigger) return;
+      const data = state.triggerData.get(trigger);
+      if (!data) return;
+
+      if (data.resetTimer) {
+        clearTimeout(data.resetTimer);
+        data.resetTimer = null;
+      }
+
+      const label = trigger.querySelector('span');
+      if (label && data.originalLabel) {
+        label.textContent = data.originalLabel;
+      }
+
+      trigger.classList.remove('choose-size-btn--added', 'choose-size-btn--loading');
+      trigger.removeAttribute('aria-busy');
+
+      if (state.activeTrigger === trigger && !targetTrigger) {
+        state.activeTrigger = null;
+      }
+    });
   }
 
   function handleSizeSelection(sectionId, variant, button) {
@@ -274,10 +383,12 @@
     }
     button.classList.add('size-option--active');
 
+    syncVariantOptionSelections(sectionId, variant);
     updateProductFormVariant(sectionId, variant.id);
 
-    const chooseButton = document.querySelector(`[data-size-drawer-trigger="${sectionId}"]`);
     const state = ensureState(sectionId);
+    const chooseButton = state.activeTrigger || state.triggers[0] || null;
+    const triggerData = chooseButton ? state.triggerData.get(chooseButton) : null;
 
     setStatus(sectionId, 'Adicionando ao carrinho...');
     button.classList.add('size-option--loading');
@@ -299,7 +410,15 @@
             label.textContent = 'Adicionado!';
           }
           chooseButton.classList.add('choose-size-btn--added');
-          state.resetTimer = setTimeout(() => resetTriggerLabel(sectionId), 2000);
+          if (triggerData) {
+            if (triggerData.resetTimer) {
+              clearTimeout(triggerData.resetTimer);
+            }
+            triggerData.resetTimer = setTimeout(() => {
+              triggerData.resetTimer = null;
+              resetTriggerLabel(sectionId, chooseButton);
+            }, 2000);
+          }
         }
       })
       .catch((error) => {
@@ -404,11 +523,11 @@
     const drawer = document.getElementById(`size-drawer-${sectionId}`);
     if (!drawer) return;
 
-    ensureState(sectionId);
+    const state = ensureState(sectionId);
     renderSizeOptions(sectionId);
 
-    const state = ensureState(sectionId);
     state.lastFocused = triggerElement || document.activeElement;
+    state.activeTrigger = triggerElement || state.triggers[0] || null;
 
     drawer.classList.add('is-open');
     drawer.setAttribute('aria-hidden', 'false');
@@ -428,8 +547,11 @@
     drawer.classList.remove('is-open');
     drawer.setAttribute('aria-hidden', 'true');
     const state = stateBySection.get(sectionId);
-    if (state?.lastFocused) {
-      state.lastFocused.focus();
+    if (state) {
+      if (state.lastFocused) {
+        state.lastFocused.focus();
+      }
+      state.activeTrigger = null;
     }
   }
 

--- a/sections/desktop-product.liquid
+++ b/sections/desktop-product.liquid
@@ -645,42 +645,53 @@ document.addEventListener('DOMContentLoaded', function() {
     return;
   }
   
-  var fieldsets = variantPickerEl.querySelectorAll('.product-form__input');
-  if (!fieldsets.length) {
+  var optionWrappers = variantPickerEl.querySelectorAll('.product-form__input');
+  if (!optionWrappers.length) {
     console.warn("No product-form__input fieldsets found in variant-picker");
     return;
   }
-  
+
+  var optionCount = Array.isArray(productData.options) ? productData.options.length : 0;
+
   function getSelectedOptions() {
-    var selected = [];
-    fieldsets.forEach(function(fieldset) {
-      var select = fieldset.querySelector('select');
+    var selected = new Array(optionCount).fill(null);
+
+    optionWrappers.forEach(function(wrapper) {
+      var positionAttr = wrapper.getAttribute('data-option-position');
+      if (!positionAttr) {
+        return;
+      }
+
+      var index = parseInt(positionAttr, 10) - 1;
+      if (isNaN(index) || index < 0 || index >= selected.length) {
+        return;
+      }
+
+      var select = wrapper.querySelector('select');
       if (select) {
-        if (select.value === "") {
-          selected.push(null);
-        } else {
-          selected.push(select.value.trim());
+        if (select.value !== "") {
+          selected[index] = select.value.trim();
         }
       } else {
-        var radios = fieldset.querySelectorAll('input[type="radio"]');
+        var radios = wrapper.querySelectorAll('input[type="radio"]');
         var found = false;
         radios.forEach(function(radio) {
           if (radio.checked) {
-            selected.push(radio.value.trim());
+            selected[index] = radio.value.trim();
             found = true;
           }
         });
-        if (!found) {
-          selected.push(null);
-        }
       }
     });
     return selected;
   }
-  
+
   function findVariant(selectedOptions) {
     return productData.variants.find(function(variant) {
       return variant.options.every(function(opt, idx) {
+        if (selectedOptions[idx] === null || selectedOptions[idx] === undefined || selectedOptions[idx] === '') {
+          return true;
+        }
         return String(selectedOptions[idx]).toLowerCase() === String(opt).toLowerCase();
       });
     });
@@ -712,12 +723,14 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
   
-  fieldsets.forEach(function(fieldset) {
-    var elements = fieldset.querySelectorAll('input, select');
+  optionWrappers.forEach(function(wrapper) {
+    var elements = wrapper.querySelectorAll('input, select');
     elements.forEach(function(el) {
       el.addEventListener('change', updateVariant);
     });
   });
+
+  updateVariant();
 });
 </script>
 

--- a/snippets/desktop-variant-picker.liquid
+++ b/snippets/desktop-variant-picker.liquid
@@ -16,6 +16,12 @@
   >
     {%- for option in product.options_with_values -%}
       {%- liquid
+        assign option_name_lower = option.name | downcase
+        assign is_size_option = false
+        if option_name_lower contains 'size' or option_name_lower contains 'tamanho' or option_name_lower contains 'talla'
+          assign is_size_option = true
+        endif
+
         assign swatch_count = option.values | map: 'swatch' | compact | size
         assign picker_type = block.settings.picker_type
 
@@ -26,25 +32,29 @@
             assign picker_type = 'swatch'
           endif
         endif
-      -%}
-      
-      {%- comment %}
-        For Size options, force dropdown so we can add a placeholder.
-      {%- endcomment -%}
-      {%- if option.name contains "Size" -%}
-        {% assign picker_type = "button" %}
-      {%- endif -%}
-      
-      {%- comment %}
-        For Color options, force swatch dropdown so the swatch is shown.
-      {%- endcomment -%}
-      {%- if option.name contains "Color" or option.name contains "Cor" -%}
-        {% assign picker_type = "swatch" %}
-      {%- endif -%}
-      
-      {%- if picker_type == 'swatch' -%}
-        <fieldset class="js product-form__input product-form__input--swatch">
 
+        if option_name_lower contains 'color' or option_name_lower contains 'cor' or option_name_lower contains 'couleur'
+          assign picker_type = 'swatch'
+        endif
+      -%}
+
+      {%- capture wrapper_attributes -%}
+data-option-position="{{ option.position }}" data-option-name="{{ option.name | escape }}"{% if is_size_option %} data-size-option="true"{% endif %}
+      {%- endcapture -%}
+      {%- assign wrapper_attributes = wrapper_attributes | strip -%}
+
+      {%- if picker_type == 'swatch' -%}
+        <fieldset
+          class="js product-form__input product-form__input--swatch{% if is_size_option %} product-form__input--size-hidden{% endif %}"
+          {{ wrapper_attributes }}
+          {% if is_size_option %}hidden aria-hidden="true"{% endif %}
+        >
+          <legend class="form__label">
+            {{ option.name }}:
+            <span data-selected-value>
+              {{- option.selected_value -}}
+            </span>
+          </legend>
           {% render 'product-variant-options',
             product: product,
             option: option,
@@ -53,7 +63,11 @@
           %}
         </fieldset>
       {%- elsif picker_type == 'button' -%}
-        <fieldset class="js product-form__input product-form__input--pill">
+        <fieldset
+          class="js product-form__input product-form__input--pill{% if is_size_option %} product-form__input--size-hidden{% endif %}"
+          {{ wrapper_attributes }}
+          {% if is_size_option %}hidden aria-hidden="true"{% endif %}
+        >
           <legend class="form__label">{{ option.name }}</legend>
           {% render 'product-variant-options',
             product: product,
@@ -63,7 +77,11 @@
           %}
         </fieldset>
       {%- else -%}
-        <div class="product-form__input product-form__input--dropdown">
+        <div
+          class="product-form__input product-form__input--dropdown{% if is_size_option %} product-form__input--size-hidden{% endif %}"
+          {{ wrapper_attributes }}
+          {% if is_size_option %}hidden aria-hidden="true"{% endif %}
+        >
           <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
             {{ option.name }}
           </label>
@@ -82,21 +100,13 @@
               name="options[{{ option.name | escape }}]"
               form="{{ product_form_id }}"
             >
-              {%- comment %}
-                If this is a size option, insert a placeholder.
-              {%- endcomment -%}
-              {%- if option.name contains "Size" -%}
-                <option value="" disabled selected>Size</option>
-              {%- endif -%}
               {% render 'product-variant-options',
                 product: product,
                 option: option,
                 block: block,
                 picker_type: picker_type
               %}
-              
             </select>
-            {% render 'size-chart-new', section_id: section.id %}
             <span class="svg-wrapper">
               {{- 'icon-caret.svg' | inline_asset_content -}}
             </span>

--- a/snippets/product-variant-picker.liquid
+++ b/snippets/product-variant-picker.liquid
@@ -28,86 +28,91 @@
         endif
       -%}
       
-      {%- comment %}
-        COMPLETELY HIDE SIZE OPTIONS - These are now handled by the size drawer
-        Skip rendering any option that contains size-related terms
-      {%- endcomment -%}
-      {%- assign is_size_option = false -%}
       {%- assign option_name_lower = option.name | downcase -%}
+      {%- assign is_size_option = false -%}
       {%- if option_name_lower contains 'size' or option_name_lower contains 'tamanho' or option_name_lower contains 'talla' -%}
         {%- assign is_size_option = true -%}
       {%- endif -%}
-      
-      {%- unless is_size_option -%}
-        
-        {%- comment %}
-          For Color options, force swatch so the swatch is shown.
-        {%- endcomment -%}
-        {%- assign option_name_lower = option.name | downcase -%}
-        {%- if option_name_lower contains 'color' or option_name_lower contains 'cor' or option_name_lower contains 'couleur' -%}
-          {% assign picker_type = "swatch" %}
-        {%- endif -%}
-        
-        {%- if picker_type == 'swatch' -%}
-          <fieldset class="js product-form__input product-form__input--swatch">
-            <legend class="form__label">
-              {{ option.name }}:
-              <span data-selected-value>
-                {{- option.selected_value -}}
-              </span>
-            </legend>
-            {% render 'product-variant-options',
-              product: product,
-              option: option,
-              block: block,
-              picker_type: picker_type
-            %}
-          </fieldset>
-        {%- elsif picker_type == 'button' -%}
-          <fieldset class="js product-form__input product-form__input--pill">
-            <legend class="form__label">{{ option.name }}</legend>
-            {% render 'product-variant-options',
-              product: product,
-              option: option,
-              block: block,
-              picker_type: picker_type
-            %}
-          </fieldset>
-        {%- else -%}
-          <div class="product-form__input product-form__input--dropdown">
-            <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
-              {{ option.name }}
-            </label>
-            <div class="select">
-              {%- if picker_type == 'swatch_dropdown' -%}
-                <span
-                  data-selected-value
-                  class="dropdown-swatch"
-                >
-                  {% render 'swatch', swatch: option.selected_value.swatch, shape: block.settings.swatch_shape %}
-                </span>
-              {%- endif -%}
-              <select
-                id="Option-{{ section.id }}-{{ forloop.index0 }}"
-                class="select__select"
-                name="options[{{ option.name | escape }}]"
-                form="{{ product_form_id }}"
+
+      {%- if option_name_lower contains 'color' or option_name_lower contains 'cor' or option_name_lower contains 'couleur' -%}
+        {% assign picker_type = 'swatch' %}
+      {%- endif -%}
+
+      {%- capture wrapper_attributes -%}
+data-option-position="{{ option.position }}" data-option-name="{{ option.name | escape }}"{% if is_size_option %} data-size-option="true"{% endif %}
+      {%- endcapture -%}
+      {%- assign wrapper_attributes = wrapper_attributes | strip -%}
+
+      {%- if picker_type == 'swatch' -%}
+        <fieldset
+          class="js product-form__input product-form__input--swatch{% if is_size_option %} product-form__input--size-hidden{% endif %}"
+          {{ wrapper_attributes }}
+          {% if is_size_option %}hidden aria-hidden="true"{% endif %}
+        >
+          <legend class="form__label">
+            {{ option.name }}:
+            <span data-selected-value>
+              {{- option.selected_value -}}
+            </span>
+          </legend>
+          {% render 'product-variant-options',
+            product: product,
+            option: option,
+            block: block,
+            picker_type: picker_type
+          %}
+        </fieldset>
+      {%- elsif picker_type == 'button' -%}
+        <fieldset
+          class="js product-form__input product-form__input--pill{% if is_size_option %} product-form__input--size-hidden{% endif %}"
+          {{ wrapper_attributes }}
+          {% if is_size_option %}hidden aria-hidden="true"{% endif %}
+        >
+          <legend class="form__label">{{ option.name }}</legend>
+          {% render 'product-variant-options',
+            product: product,
+            option: option,
+            block: block,
+            picker_type: picker_type
+          %}
+        </fieldset>
+      {%- else -%}
+        <div
+          class="product-form__input product-form__input--dropdown{% if is_size_option %} product-form__input--size-hidden{% endif %}"
+          {{ wrapper_attributes }}
+          {% if is_size_option %}hidden aria-hidden="true"{% endif %}
+        >
+          <label class="form__label" for="Option-{{ section.id }}-{{ forloop.index0 }}">
+            {{ option.name }}
+          </label>
+          <div class="select">
+            {%- if picker_type == 'swatch_dropdown' -%}
+              <span
+                data-selected-value
+                class="dropdown-swatch"
               >
-                {% render 'product-variant-options',
-                  product: product,
-                  option: option,
-                  block: block,
-                  picker_type: picker_type
-                %}
-              </select>
-              <span class="svg-wrapper">
-                {{- 'icon-caret.svg' | inline_asset_content -}}
+                {% render 'swatch', swatch: option.selected_value.swatch, shape: block.settings.swatch_shape %}
               </span>
-            </div>
+            {%- endif -%}
+            <select
+              id="Option-{{ section.id }}-{{ forloop.index0 }}"
+              class="select__select"
+              name="options[{{ option.name | escape }}]"
+              form="{{ product_form_id }}"
+            >
+              {% render 'product-variant-options',
+                product: product,
+                option: option,
+                block: block,
+                picker_type: picker_type
+              %}
+            </select>
+            <span class="svg-wrapper">
+              {{- 'icon-caret.svg' | inline_asset_content -}}
+            </span>
           </div>
-        {%- endif -%}
-        
-      {%- endunless -%}
+        </div>
+      {%- endif -%}
     {%- endfor -%}
 
     <script type="application/json" data-selected-variant>


### PR DESCRIPTION
## Summary
- keep Shopify variant option inputs in the markup while hiding size pickers so variant scripts still run on mobile and sticky forms
- sync hidden variant option inputs when a size is chosen from the drawer and avoid redundant product-form change events
- ensure the size drawer updates the product form only when the variant id actually changes to prevent unnecessary change handlers

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b86759e88325a04c15da8d2500fd